### PR TITLE
Remove reference of concat in favor of combine

### DIFF
--- a/lib/preface_make/monoid.ml
+++ b/lib/preface_make/monoid.ml
@@ -30,7 +30,7 @@ module Via
   include Infix
 end
 
-module Via_concat_and_zero (Core : Preface_specs.Monoid.CORE) :
+module Via_combine_and_zero (Core : Preface_specs.Monoid.CORE) :
   Preface_specs.MONOID with type t = Core.t = struct
   include Core
   module Operation = Operation (Core)

--- a/lib/preface_make/monoid.mli
+++ b/lib/preface_make/monoid.mli
@@ -10,8 +10,8 @@ module Over_semigroup
     (M : Preface_specs.Monoid.NEUTRAL with type t = S.t) :
   Preface_specs.MONOID with type t = S.t
 
-(** Incarnation of a [Monoid] with [concat] and [zero]. *)
-module Via_concat_and_zero (Core : Preface_specs.Monoid.CORE) :
+(** Incarnation of a [Monoid] with [combine] and [zero]. *)
+module Via_combine_and_zero (Core : Preface_specs.Monoid.CORE) :
   Preface_specs.MONOID with type t = Core.t
 
 (** {2 Manual construction}

--- a/lib/preface_make/semigroup.ml
+++ b/lib/preface_make/semigroup.ml
@@ -31,7 +31,7 @@ module Via
   include Infix
 end
 
-module Via_concat (Core : Preface_specs.Semigroup.CORE) :
+module Via_combine (Core : Preface_specs.Semigroup.CORE) :
   Preface_specs.SEMIGROUP with type t = Core.t = struct
   include Core
   module Operation = Operation (Core)

--- a/lib/preface_make/semigroup.mli
+++ b/lib/preface_make/semigroup.mli
@@ -4,8 +4,8 @@
 
     Standard way to build a [Semigroup]. *)
 
-(** Incarnation of a [Semigroup] with [concat]. *)
-module Via_concat (Core : Preface_specs.Semigroup.CORE) :
+(** Incarnation of a [Semigroup] with [combine]. *)
+module Via_combine (Core : Preface_specs.Semigroup.CORE) :
   Preface_specs.SEMIGROUP with type t = Core.t
 
 (** {2 Manual construction}

--- a/lib/preface_stdlib/list.ml
+++ b/lib/preface_stdlib/list.ml
@@ -94,7 +94,7 @@ module Selective =
     (Preface_make.Selective.Select_from_monad (Monad))
 
 module Monoid (T : Preface_specs.Types.T0) =
-Preface_make.Monoid.Via_concat_and_zero (struct
+Preface_make.Monoid.Via_combine_and_zero (struct
   type nonrec t = T.t t
 
   let combine l r = l @ r

--- a/lib/preface_stdlib/nonempty_list.ml
+++ b/lib/preface_stdlib/nonempty_list.ml
@@ -94,7 +94,7 @@ module Selective =
 
 module Semigroup (T : Preface_specs.Types.T0) :
   Preface_specs.SEMIGROUP with type t = T.t t =
-Preface_make.Semigroup.Via_concat (struct
+Preface_make.Semigroup.Via_combine (struct
   type nonrec t = T.t t
 
   let combine = append

--- a/lib/preface_stdlib/option.ml
+++ b/lib/preface_stdlib/option.ml
@@ -27,7 +27,7 @@ module Monad = Preface_make.Monad.Via_bind (struct
 end)
 
 module Monoid (M : Preface_specs.SEMIGROUP) =
-Preface_make.Monoid.Via_concat_and_zero (struct
+Preface_make.Monoid.Via_combine_and_zero (struct
   type nonrec t = M.t t
 
   let neutral = None

--- a/test/preface_stdlib_test/monoid_test.ml
+++ b/test/preface_stdlib_test/monoid_test.ml
@@ -1,6 +1,6 @@
 module N = Preface_core.Nonempty_list
 
-module S = Preface_make.Monoid.Via_concat_and_zero (struct
+module S = Preface_make.Monoid.Via_combine_and_zero (struct
   type t = string
 
   let combine = ( ^ )
@@ -8,7 +8,7 @@ module S = Preface_make.Monoid.Via_concat_and_zero (struct
   let neutral = ""
 end)
 
-module I = Preface_make.Monoid.Via_concat_and_zero (struct
+module I = Preface_make.Monoid.Via_combine_and_zero (struct
   type t = int
 
   let combine = ( + )
@@ -16,16 +16,16 @@ module I = Preface_make.Monoid.Via_concat_and_zero (struct
   let neutral = 0
 end)
 
-let string_concat () =
+let string_combine () =
   let expected = "FooBar"
   and computed = S.("Foo" ++ "Bar") in
-  Alcotest.(check string) "string_concat" expected computed
+  Alcotest.(check string) "string_combine" expected computed
 ;;
 
-let int_concat () =
+let int_combine () =
   let expected = 16
   and computed = I.(6 ++ 10) in
-  Alcotest.(check int) "int_concat" expected computed
+  Alcotest.(check int) "int_combine" expected computed
 ;;
 
 let string_times_1 () =
@@ -105,8 +105,8 @@ let test_cases =
   [
     ( "Monoid"
     , [
-        test_case "String concat" `Quick string_concat
-      ; test_case "Int concat" `Quick int_concat
+        test_case "String combine" `Quick string_combine
+      ; test_case "Int combine" `Quick int_combine
       ; test_case "String times 1" `Quick string_times_1
       ; test_case "String times 2" `Quick string_times_2
       ; test_case "Int times 1" `Quick int_times_1

--- a/test/preface_stdlib_test/semigroup_test.ml
+++ b/test/preface_stdlib_test/semigroup_test.ml
@@ -1,27 +1,27 @@
 module N = Preface_core.Nonempty_list
 
-module S = Preface_make.Semigroup.Via_concat (struct
+module S = Preface_make.Semigroup.Via_combine (struct
   type t = string
 
   let combine = ( ^ )
 end)
 
-module I = Preface_make.Semigroup.Via_concat (struct
+module I = Preface_make.Semigroup.Via_combine (struct
   type t = int
 
   let combine = ( + )
 end)
 
-let string_concat () =
+let string_combine () =
   let expected = "FooBar"
   and computed = S.("Foo" ++ "Bar") in
-  Alcotest.(check string) "string_concat" expected computed
+  Alcotest.(check string) "string_combine" expected computed
 ;;
 
-let int_concat () =
+let int_combine () =
   let expected = 16
   and computed = I.(6 ++ 10) in
-  Alcotest.(check int) "int_concat" expected computed
+  Alcotest.(check int) "int_combine" expected computed
 ;;
 
 let string_times_1 () =
@@ -77,8 +77,8 @@ let test_cases =
   [
     ( "Semigroup"
     , [
-        test_case "String concat" `Quick string_concat
-      ; test_case "Int concat" `Quick int_concat
+        test_case "String combine" `Quick string_combine
+      ; test_case "Int combine" `Quick int_combine
       ; test_case "String times 1" `Quick string_times_1
       ; test_case "String times 2" `Quick string_times_2
       ; test_case "Int times 1" `Quick int_times_1


### PR DESCRIPTION
When we move from `concat` to `combine`. I've forgot to change the functor name.