### PR TITLE
Fix small typo in State documentation

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.14.1
+version = 0.14.2
 margin = 80
 max-indent = 68
 
@@ -24,7 +24,7 @@ cases-matching-exp-indent = normal
 
 disambiguate-non-breaking-match = true
 
-doc-comments = after
+doc-comments = after-when-possible
 doc-comments-padding = 2
 doc-comments-tag-only = default
 dock-collection-brackets = true

--- a/lib/preface_specs/dune
+++ b/lib/preface_specs/dune
@@ -1,8 +1,7 @@
 (library
  (name preface_specs)
  (public_name preface.specs)
- (modules_without_implementation
-   preface_specs types functor applicative
-   selective monad comonad traversable bifunctor free_monad freer_monad semigroup
-   monoid)
+ (modules_without_implementation preface_specs types functor applicative
+   selective monad comonad traversable bifunctor free_monad freer_monad
+   semigroup monoid)
  (libraries preface.core))

--- a/lib/preface_stdlib/state.mli
+++ b/lib/preface_stdlib/state.mli
@@ -62,11 +62,11 @@
         let open State in
         let open State.Monad in
         let* () = add (2, 1) in
-        let* () = mult 3
-            get
+        let* () = mult 3 in
+        get
       ;;
 
-      let v = fst (program (1,0)) (* v is the vector (9, 3) *)
+      let v = fst (program (1, 0)) (* v is the vector (9, 3) *)
     ]} *)
 
 (** {1 Implementation} *)


### PR DESCRIPTION
In order to give a proper review of Reader, I've rewrite State and I find a small typo.