### PR TITLE
Add contravariant functor

### DIFF
--- a/lib/preface_make/contravariant.ml
+++ b/lib/preface_make/contravariant.ml
@@ -1,0 +1,45 @@
+open Preface_core.Fun
+
+module Operation (Core : Preface_specs.Contravariant.CORE) :
+  Preface_specs.Contravariant.OPERATION with type 'a t = 'a Core.t = struct
+  type 'a t = 'a Core.t
+
+  let replace x c = (Core.contramap % constant) x c
+end
+
+module Infix
+    (Core : Preface_specs.Contravariant.CORE)
+    (Operation : Preface_specs.Contravariant.OPERATION
+                   with type 'a t = 'a Core.t) :
+  Preface_specs.Contravariant.INFIX with type 'a t = 'a Operation.t = struct
+  type 'a t = 'a Core.t
+
+  let ( >$ ) x c = Operation.replace x c
+
+  let ( $< ) c x = Operation.replace x c
+
+  let ( >$< ) f c = Core.contramap f c
+
+  let ( >&< ) c f = Core.contramap f c
+end
+
+module Via
+    (Core : Preface_specs.Contravariant.CORE)
+    (Operation : Preface_specs.Contravariant.OPERATION
+                   with type 'a t = 'a Core.t)
+    (Infix : Preface_specs.Contravariant.INFIX with type 'a t = 'a Operation.t) :
+  Preface_specs.CONTRAVARIANT with type 'a t = 'a Infix.t = struct
+  include Core
+  include Operation
+  include Infix
+  module Infix = Infix
+end
+
+module Via_contramap (Core : Preface_specs.Contravariant.CORE) :
+  Preface_specs.CONTRAVARIANT with type 'a t = 'a Core.t = struct
+  include Core
+  module Operation = Operation (Core)
+  include Operation
+  module Infix = Infix (Core) (Operation)
+  include Infix
+end

--- a/lib/preface_make/contravariant.mli
+++ b/lib/preface_make/contravariant.mli
@@ -1,0 +1,37 @@
+(** Modules for building {!Preface_specs.CONTRAVARIANT} modules.
+
+    {1 Documentation}
+
+    {2 Construction}
+
+    Standard way to build a [Contravariant Functor]. *)
+
+(** Incarnation of a [Contravariant] using [contramap]. *)
+module Via_contramap (Core : Preface_specs.Contravariant.CORE) :
+  Preface_specs.CONTRAVARIANT with type 'a t = 'a Core.t
+
+(** {2 Manual construction}
+
+    Advanced way to build a [Contravariant], constructing and assembling a
+    component-by-component an arrow. (In order to provide your own
+    implementation for some features.) *)
+
+(** Incarnation of an [Contravariant] using each components of a
+    [Contravariant]. *)
+module Via
+    (Core : Preface_specs.Contravariant.CORE)
+    (Operation : Preface_specs.Contravariant.OPERATION
+                   with type 'a t = 'a Core.t)
+    (Infix : Preface_specs.Contravariant.INFIX with type 'a t = 'a Operation.t) :
+  Preface_specs.CONTRAVARIANT with type 'a t = 'a Infix.t
+
+(** Incarnation of [Contravariant.Operation] using [Core]. *)
+module Operation (Core : Preface_specs.Contravariant.CORE) :
+  Preface_specs.Contravariant.OPERATION with type 'a t = 'a Core.t
+
+(** Incarnation of [Contravariant.Infix] using [Core] and [Operation]. *)
+module Infix
+    (Core : Preface_specs.Contravariant.CORE)
+    (Operation : Preface_specs.Contravariant.OPERATION
+                   with type 'a t = 'a Core.t) :
+  Preface_specs.Contravariant.INFIX with type 'a t = 'a Operation.t

--- a/lib/preface_specs/contravariant.mli
+++ b/lib/preface_specs/contravariant.mli
@@ -1,0 +1,57 @@
+(** [Contravariant] is a "Contravariant functor". *)
+
+(** {1 Structure anatomy} *)
+
+(** Standard requirement. *)
+module type CORE = sig
+  type 'a t
+  (** The type held by the [Contravriant Functor]. *)
+
+  val contramap : ('a -> 'b) -> 'b t -> 'a t
+  (** Mapping over from ['a] to ['b] over ['b t] to ['a t]. *)
+end
+
+(** Operations *)
+module type OPERATION = sig
+  type 'a t
+  (** The type held by the [Contravriant Functor]. *)
+
+  val replace : 'b -> 'b t -> 'a t
+  (** Replace all locations in the output with the same value. *)
+end
+
+(** Infix notation *)
+module type INFIX = sig
+  type 'a t
+  (** The type held by the [Contravriant Functor]. *)
+
+  val ( >$ ) : 'b -> 'b t -> 'a t
+  (** Infix version of {!val:OPERATION.replace}. *)
+
+  val ( $< ) : 'b t -> 'b -> 'a t
+  (** Infix flipped version of {!val:OPERATION.replace}. *)
+
+  val ( >$< ) : ('a -> 'b) -> 'b t -> 'a t
+  (** Infix version of {!val:CORE.map}. *)
+
+  val ( >&< ) : 'b t -> ('a -> 'b) -> 'a t
+  (** Infix flipped version of {!val:CORE.map}. *)
+end
+
+(** {1 API} *)
+
+(** The complete interface of a [Contravariant Functor]. *)
+module type API = sig
+  include CORE
+
+  include OPERATION with type 'a t := 'a t
+
+  module Infix : INFIX with type 'a t := 'a t
+
+  include module type of Infix
+end
+
+(** {1 Bibliography}
+
+    - {{:https://typeclasses.com/contravariance}
+      https://typeclasses.com/contravariance} *)

--- a/lib/preface_specs/dune
+++ b/lib/preface_specs/dune
@@ -4,5 +4,5 @@
  (modules_without_implementation preface_specs types functor applicative
    selective monad comonad traversable bifunctor free_applicative free_monad
    freer_monad free_selective semigroup monoid foldable alt alternative
-   monad_plus category arrow arrow_zero arrow_alt arrow_plus)
+   monad_plus contravariant category arrow arrow_zero arrow_alt arrow_plus)
  (libraries preface.core either))

--- a/lib/preface_specs/preface_specs.mli
+++ b/lib/preface_specs/preface_specs.mli
@@ -99,6 +99,9 @@ module Free_monad = Free_monad
 module Freer_monad = Freer_monad
 (** Describes a freer monad. *)
 
+module Contravariant = Contravariant
+(** Describes a Contravariant Functor. *)
+
 module Category = Category
 (** Describes a category. *)
 
@@ -152,6 +155,8 @@ module type FREE_SELECTIVE = Free_selective.API
 module type FREE_MONAD = Free_monad.API
 
 module type FREER_MONAD = Freer_monad.API
+
+module type CONTRAVARIANT = Contravariant.API
 
 module type CATEGORY = Category.API
 

--- a/lib/preface_stdlib/predicate.ml
+++ b/lib/preface_stdlib/predicate.ml
@@ -1,0 +1,11 @@
+type 'a t = 'a -> bool
+
+let lift f = f
+
+let run f x = f x
+
+module Contravariant = Preface_make.Contravariant.Via_contramap (struct
+  type nonrec 'a t = 'a t
+
+  let contramap f g = Preface_core.Fun.(g % f)
+end)

--- a/lib/preface_stdlib/predicate.mli
+++ b/lib/preface_stdlib/predicate.mli
@@ -1,0 +1,22 @@
+(** Exposes [Predicate.t], a function from ['a] to [bool].
+
+    {1 Capabilities}
+
+    - {!val:Contravariant} *)
+
+(** {1 Type} *)
+
+type 'a t
+
+(** {1 Implementation} *)
+
+module Contravariant : Preface_specs.CONTRAVARIANT with type 'a t = 'a t
+(** {2 Foldable API} *)
+
+(** {1 Helpers} *)
+
+val lift : ('a -> bool) -> 'a t
+(** Lift a function from ['a] to [bool] into a predicate. *)
+
+val run : 'a t -> 'a -> bool
+(** Run a predicate. *)

--- a/test/preface_laws/contravariant.ml
+++ b/test/preface_laws/contravariant.ml
@@ -1,0 +1,70 @@
+open Preface_qcheck
+
+module Preserve_identity
+    (F : Preface_specs.Contravariant.CORE)
+    (A : Model.T1 with type 'a t = 'a F.t)
+    (X : Model.T0) =
+Preface_qcheck.Make.Test (struct
+  let name = "map id = id"
+
+  type input = X.t F.t
+
+  type output = input
+
+  let arbitrary = A.arbitrary X.arbitrary
+
+  let equal = A.equal X.equal
+
+  let left x = F.contramap (fun x -> x) x
+
+  let right x = (fun x -> x) x
+end)
+
+module Preserve_morphism
+    (F : Preface_specs.Contravariant.CORE)
+    (A : Model.T1 with type 'a t = 'a F.t)
+    (X : Model.T0)
+    (Y : Model.T0)
+    (Z : Model.T0) =
+Preface_qcheck.Make.Test (struct
+  let name = "contramap (f % g) = contramap g % contramap f"
+
+  type input = X.t F.t * (Y.t -> Z.t) QCheck.fun_ * (Z.t -> X.t) QCheck.fun_
+
+  type output = Y.t F.t
+
+  let arbitrary =
+    let open QCheck in
+    triple (A.arbitrary X.arbitrary)
+      (fun1 Y.observable Z.arbitrary)
+      (fun1 Z.observable X.arbitrary)
+  ;;
+
+  let equal = A.equal Y.equal
+
+  let left (x, f', g') =
+    let f = QCheck.Fn.apply f'
+    and g = QCheck.Fn.apply g' in
+    Preface_core.Fun.Infix.(F.contramap (g % f) x)
+  ;;
+
+  let right (x, f', g') =
+    let f = QCheck.Fn.apply f'
+    and g = QCheck.Fn.apply g' in
+    Preface_core.Fun.Infix.(F.contramap f % F.contramap g) x
+  ;;
+end)
+
+module Cases
+    (F : Preface_specs.Contravariant.CORE)
+    (A : Model.T1 with type 'a t = 'a F.t)
+    (T : Sample.PACKAGE) =
+struct
+  module Id = Preserve_identity (F) (A) (T.A)
+  module Morphsim = Preserve_morphism (F) (A) (T.A) (T.B) (T.C)
+
+  let cases n =
+    [ Id.test n; Morphsim.test n ]
+    |> Stdlib.List.map QCheck_alcotest.to_alcotest
+  ;;
+end

--- a/test/preface_laws/contravariant.mli
+++ b/test/preface_laws/contravariant.mli
@@ -1,0 +1,8 @@
+(** Test cases for [Contravariant functors] *)
+
+module Cases
+    (F : Preface_specs.Contravariant.CORE)
+    (A : Preface_qcheck.Model.T1 with type 'a t = 'a F.t)
+    (T : Preface_qcheck.Sample.PACKAGE) : sig
+  val cases : int -> unit Alcotest.test_case list
+end

--- a/test/preface_laws/dune
+++ b/test/preface_laws/dune
@@ -3,12 +3,12 @@
  (public_name preface.laws)
  (synopsis "Encoding laws as a set of tests")
  (modules functor applicative selective monad comonad bifunctor semigroup
-   monoid alternative monad_plus alt)
+   monoid alternative monad_plus alt contravariant)
  (libraries qcheck-core qcheck-alcotest preface.core preface.specs
    preface.make preface.stdlib preface.qcheck))
 
 (test
  (name preface_laws_suite)
  (modules misc identity continuation option list nonempty_list try either
-   stream result validation validate state preface_laws_suite)
+   stream result validation validate state predicate preface_laws_suite)
  (libraries preface.qcheck preface.stdlib alcotest preface_laws))

--- a/test/preface_laws/predicate.ml
+++ b/test/preface_laws/predicate.ml
@@ -1,0 +1,43 @@
+let preserve_identity (module P : Preface_qcheck.Model.T0) count =
+  let open QCheck in
+  let arbitrary = pair (fun1 P.observable bool) P.arbitrary in
+  Test.make ~name:"map id = id" ~count arbitrary (fun (f', value) ->
+      let open Preface_stdlib.Predicate in
+      let f = lift (Fn.apply f') in
+      let l = run (Contravariant.contramap (fun x -> x) f) value
+      and r = run f value in
+      Bool.equal l r)
+;;
+
+let preserve_morphism (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary =
+    quad (fun1 P.A.observable bool)
+      (fun1 P.C.observable P.D.arbitrary)
+      (fun1 P.D.observable P.A.arbitrary)
+      P.C.arbitrary
+  in
+  Test.make ~name:"contramap (f % g) = contramap g % contramap f" ~count
+    arbitrary (fun (x', f', g', value) ->
+      let open Preface_stdlib.Predicate in
+      let open Preface_core.Fun.Infix in
+      let x = lift (Fn.apply x') in
+      let f = Fn.apply f' in
+      let g = Fn.apply g' in
+      let l = run (Contravariant.contramap (g % f) x) value
+      and r =
+        run ((Contravariant.contramap f % Contravariant.contramap g) x) value
+      in
+      Bool.equal l r)
+;;
+
+let cases n =
+  [
+    ( "Predicate Contravariant Functor Laws"
+    , [
+        preserve_identity (module Preface_qcheck.Sample.Pack1.A) n
+      ; preserve_morphism (module Preface_qcheck.Sample.Pack1) n
+      ]
+      |> Stdlib.List.map QCheck_alcotest.to_alcotest )
+  ]
+;;

--- a/test/preface_laws/preface_laws_suite.ml
+++ b/test/preface_laws/preface_laws_suite.ml
@@ -13,7 +13,8 @@ let run number =
     @ Validate.cases number
     @ Stream.cases number
     @ Either.cases number
-    @ State.cases number )
+    @ State.cases number
+    @ Predicate.cases number )
 ;;
 
 let () = run 500


### PR DESCRIPTION
Since `Predicate` is a function (`'a t = ('a -> bool)`) I can't use @xvw's test functors for multiple reasons:
- `arbitrary` for `Model.T1` has type `'a arbitrary -> 'a t arbitrary` 
- `equal`  for `Model.T1` has type `('a -> 'a -> bool) -> 'a t -> 'a t -> bool` 

For a function type, the `arbitrary` should take an observable as first parameter and the equality should take a witness (in order to check the equality of the application). It seems complicated to have a proper generic functor so I choose to re-implement the tests in the dedicated module. Even it is not so generics, I think it is the right choice.