### PR TITLE
fix #84 relax Freer restriction

### DIFF
--- a/lib/preface_make/free_monad.mli
+++ b/lib/preface_make/free_monad.mli
@@ -52,10 +52,10 @@
       module Store_free = Preface_make.Free_monad.Over_functor (Store.Functor)
     ]}
 
-    {3 Defining an interpeter}
+    {3 Defining a Handler}
 
-    Then we can propose one interpretation using an OCaml side effect for
-    instance, here the side effect is a mutable reference
+    Then we can propose a handler using an OCaml side effect for instance, here
+    the side effect is a mutable reference
 
     {[
       let runStore l = function

--- a/lib/preface_make/freer_monad.ml
+++ b/lib/preface_make/freer_monad.ml
@@ -9,13 +9,14 @@ module Over (Type : Preface_specs.Types.T1) = struct
 
   let perform f = Bind (f, (fun a -> Return a))
 
-  type interpreter = { interpreter : 'a. 'a f -> 'a }
+  type 'a handler = { handler : 'b. ('b -> 'a) -> 'b f -> 'a }
 
   let run f =
     let rec loop_run = function
       | Return a -> a
-      | Bind (intermediate, continuation) ->
-        loop_run (continuation (f.interpreter intermediate))
+      | Bind (intermediate, continue) ->
+        let k x = loop_run (continue x) in
+        f.handler k intermediate
     in
     loop_run
   ;;

--- a/lib/preface_specs/free_monad.mli
+++ b/lib/preface_specs/free_monad.mli
@@ -1,6 +1,6 @@
 (** A [Free_monad] allows you to build a monad from a given functor. Such monad
     is equiped with two additional functions: one dedicated to the creation of a
-    new data and another one for the interpretation. *)
+    new data and another one for the effect handling. *)
 
 (** {1 Structure anatomy} *)
 
@@ -18,7 +18,7 @@ module type CORE = sig
   (** Create a new ['a t] from a ['a f]. *)
 
   val run : ('a f -> 'a) -> 'a t -> 'a
-  (** Execute a given interpret for given data *)
+  (** Execute a given handler for given data *)
 end
 
 (** {1 API} *)

--- a/lib/preface_specs/freer_monad.mli
+++ b/lib/preface_specs/freer_monad.mli
@@ -14,14 +14,14 @@ module type CORE = sig
     | Return : 'a -> 'a t
     | Bind : 'b f * ('b -> 'a t) -> 'a t
 
-  type interpreter = { interpreter : 'a. 'a f -> 'a }
-  (** The interpreter type *)
+  type 'a handler = { handler : 'b. ('b -> 'a) -> 'b f -> 'a }
+  (** The handler type *)
 
   val perform : 'a f -> 'a t
   (** Create a new ['a t] from a ['a f]. *)
 
-  val run : interpreter -> 'a t -> 'a
-  (** Execute a given interpret for given data *)
+  val run : 'a handler -> 'a t -> 'a
+  (** Execute a given handler for given data *)
 end
 
 (** {1 API} *)

--- a/test/preface_examples_test/freer_monad_consoleIO.ml
+++ b/test/preface_examples_test/freer_monad_consoleIO.ml
@@ -12,19 +12,19 @@ let tell x = IO.perform (ConsoleIO.Tell (x, id))
 
 let ask s = IO.perform (ConsoleIO.Ask (s, id))
 
-let runConsoleIO output = function
+let runConsoleIO output sk = function
   | ConsoleIO.Tell (s, k) ->
     let () = output := !output @ [ "Tell " ^ s ] in
-    k ()
+    sk (k ())
   | ConsoleIO.Ask (s, k) ->
     let () = output := !output @ [ "Ask " ^ s ^ "?" ] in
-    k s
+    sk (k s)
 ;;
 
 let runConsole output =
   let open IO in
   let i c = runConsoleIO output c in
-  { interpreter = i }
+  { handler = i }
 ;;
 
 let write_hello () =

--- a/test/preface_examples_test/freer_monad_os_effect.ml
+++ b/test/preface_examples_test/freer_monad_os_effect.ml
@@ -1,0 +1,130 @@
+let try_testable a =
+  Alcotest.testable
+    (Preface.Try.pp (Alcotest.pp a))
+    (Preface.Try.equal (Alcotest.equal a))
+;;
+
+type 'a effect =
+  | Get_home : string effect
+  | Print : string -> unit effect
+
+module Effect = struct
+  include Preface.Make.Freer_monad.Over (struct
+    type 'a t = 'a effect
+  end)
+
+  let get_home = perform Get_home
+
+  let print message = perform (Print message)
+
+  let program path =
+    let open Monad in
+    match path with
+    | Some path ->
+      let* () = print ("Path is " ^ path) in
+      return (Preface.Try.ok ())
+    | None ->
+      let* home = get_home in
+      let* () = print ("Path is " ^ home) in
+      return (Preface.Try.ok ())
+  ;;
+end
+
+exception No_home
+
+let record reference action = reference := !reference @ [ action ]
+
+let happy_path_without_path () =
+  let output = ref [] in
+  let expected = [ "get_home"; "print Path is /xhtmlboi" ] in
+  let result =
+    let open Effect in
+    run
+      {
+        handler =
+          (fun resume effect ->
+            let f : type b. (b -> 'a) -> b effect -> 'a =
+             fun resume -> function
+              | Print message ->
+                let () = record output ("print " ^ message) in
+                resume ()
+              | Get_home ->
+                let () = record output "get_home" in
+                resume "/xhtmlboi"
+            in
+            f resume effect)
+      }
+      (program None)
+  in
+  Alcotest.(check (try_testable unit)) "should be equal" result (Ok ());
+  Alcotest.(check (list string)) "should be equal" expected !output
+;;
+
+let happy_path_with_path () =
+  let output = ref [] in
+  let expected = [ "print Path is ./a-path" ] in
+  let result =
+    let open Effect in
+    run
+      {
+        handler =
+          (fun resume effect ->
+            let f : type b. (b -> 'a) -> b effect -> 'a =
+             fun resume -> function
+              | Print message ->
+                let () = record output ("print " ^ message) in
+                resume ()
+              | Get_home ->
+                let () = record output "get_home" in
+                resume "/xhtmlboi"
+            in
+            f resume effect)
+      }
+      (program (Some "./a-path"))
+  in
+  Alcotest.(check (try_testable unit)) "should be equal" result (Ok ());
+  Alcotest.(check (list string)) "should be equal" expected !output
+;;
+
+let unhappy_path_without_path () =
+  let output = ref [] in
+  let expected = [ "get_home" ] in
+  let result =
+    let open Effect in
+    run
+      {
+        handler =
+          (fun resume effect ->
+            let f : type b. (b -> 'a) -> b effect -> 'a =
+             fun resume -> function
+              | Print message ->
+                let () = record output ("print " ^ message) in
+                resume ()
+              | Get_home ->
+                let () = record output "get_home" in
+                Preface.Try.error No_home
+            in
+            f resume effect)
+      }
+      (program None)
+  in
+  Alcotest.(check (try_testable unit))
+    "should be equal" result
+    (Preface.Try.error No_home);
+  Alcotest.(check (list string)) "should be equal" expected !output
+;;
+
+let cases =
+  [
+    ( "Freer Monad OS effect"
+    , let open Alcotest in
+      [
+        test_case "Happy path: perform program without path" `Quick
+          happy_path_without_path
+      ; test_case "Happy path: perform program with path" `Quick
+          happy_path_with_path
+      ; test_case "Unhappy path: perform program without path" `Quick
+          unhappy_path_without_path
+      ] )
+  ]
+;;

--- a/test/preface_examples_test/freer_monad_os_explicit_continuation.ml
+++ b/test/preface_examples_test/freer_monad_os_explicit_continuation.ml
@@ -1,0 +1,118 @@
+let try_testable a =
+  Alcotest.testable
+    (Preface.Try.pp (Alcotest.pp a))
+    (Preface.Try.equal (Alcotest.equal a))
+;;
+
+type 'a effect =
+  | Get_home of (string -> 'a)
+  | Print of (string * (unit -> 'a))
+
+module Effect = struct
+  include Preface.Make.Freer_monad.Over (struct
+    type 'a t = 'a effect
+  end)
+
+  let get_home = perform (Get_home Fun.id)
+
+  let print message = perform (Print (message, Fun.id))
+
+  let program path =
+    let open Monad in
+    match path with
+    | Some path ->
+      let* () = print ("Path is " ^ path) in
+      return (Preface.Try.ok ())
+    | None ->
+      let* home = get_home in
+      let* () = print ("Path is " ^ home) in
+      return (Preface.Try.ok ())
+  ;;
+end
+
+exception No_home
+
+let record reference action = reference := !reference @ [ action ]
+
+let happy_path_without_path () =
+  let output = ref [] in
+  let expected = [ "get_home"; "print Path is /xhtmlboi" ] in
+  let result =
+    let open Effect in
+    run
+      {
+        handler =
+          (fun resume -> function
+            | Print (message, k) ->
+              let () = record output ("print " ^ message) in
+              resume (k ())
+            | Get_home k ->
+              let () = record output "get_home" in
+              resume (k "/xhtmlboi"))
+      }
+      (program None)
+  in
+  Alcotest.(check (try_testable unit)) "should be equal" result (Ok ());
+  Alcotest.(check (list string)) "should be equal" expected !output
+;;
+
+let happy_path_with_path () =
+  let output = ref [] in
+  let expected = [ "print Path is ./a-path" ] in
+  let result =
+    let open Effect in
+    run
+      {
+        handler =
+          (fun resume -> function
+            | Print (message, k) ->
+              let () = record output ("print " ^ message) in
+              resume (k ())
+            | Get_home k ->
+              let () = record output "get_home" in
+              resume (k "/xhtmlboi"))
+      }
+      (program (Some "./a-path"))
+  in
+  Alcotest.(check (try_testable unit)) "should be equal" result (Ok ());
+  Alcotest.(check (list string)) "should be equal" expected !output
+;;
+
+let unhappy_path_without_path () =
+  let output = ref [] in
+  let expected = [ "get_home" ] in
+  let result =
+    let open Effect in
+    run
+      {
+        handler =
+          (fun resume -> function
+            | Print (message, k) ->
+              let () = record output ("print " ^ message) in
+              resume (k ())
+            | Get_home _ ->
+              let () = record output "get_home" in
+              Preface.Try.error No_home)
+      }
+      (program None)
+  in
+  Alcotest.(check (try_testable unit))
+    "should be equal" result
+    (Preface.Try.error No_home);
+  Alcotest.(check (list string)) "should be equal" expected !output
+;;
+
+let cases =
+  [
+    ( "Freer Monad OS effect with explicit continuation"
+    , let open Alcotest in
+      [
+        test_case "Happy path: perform program without path" `Quick
+          happy_path_without_path
+      ; test_case "Happy path: perform program with path" `Quick
+          happy_path_with_path
+      ; test_case "Unhappy path: perform program without path" `Quick
+          unhappy_path_without_path
+      ] )
+  ]
+;;

--- a/test/preface_examples_test/preface_example_test.ml
+++ b/test/preface_examples_test/preface_example_test.ml
@@ -6,6 +6,8 @@ let () =
     @ Shape.cases
     @ Free_monad_consoleIO.cases
     @ Freer_monad_consoleIO.cases
+    @ Freer_monad_os_effect.cases
+    @ Freer_monad_os_explicit_continuation.cases
     @ Template_reader.cases
     @ Debruijn_reader.cases )
 ;;


### PR DESCRIPTION
I removed the limitation on `Freer`.
As you can see, the change is quite simple and is split into two parts:
- Modification of the type of interpreter (I took the opportunity to rename it Handler): ` type 'a handler = { handler : 'b. ('b -> 'a) -> 'b f -> 'a }`
- Changing the 'run' function : 
  ```ocaml
  let run f =
    let rec loop_run = function
      | Return a -> a
      | Bind (intermediate, continue) ->
        let k x = loop_run (continue x) in
        f.handler k intermediate
    in
    loop_run
  ;;
  ```
- I have added some test.

Now there is two way to handle the continuation. 

**Using explicit continuation (Like you did before)** 

```ocaml
type 'a effect =
  | Get_home of (string -> 'a)
  | Print of (string * (unit -> 'a))
```
The handler is easy to write but you have to handle two level of continuation: 
```ocaml
run
      {
        handler =
          (fun resume -> function
            | Print (message, k) ->
              let () = record output ("print " ^ message) in
              resume (k ())
            | Get_home k ->
              let () = record output "get_home" in
              resume (k "/xhtmlboi"))
      }
      (program None)
```
(And discarding the continuation obviously works :))

**Using implicit continuation** 
```ocaml
type 'a effect =
  | Get_home : string effect
  | Print : string -> unit effect

(* and now... no more Fun.id "a gogo" *)

let get_home = perform Get_home
let print message = perform (Print message)
```
The handler need some types anotation (but does not require two level of continuation) 
```ocaml
run
      {
        handler =
          (fun resume effect ->
            let f : type b. (b -> 'a) -> b effect -> 'a =
             fun resume -> function
              | Print message ->
                let () = record output ("print " ^ message) in
                resume ()
              | Get_home ->
                let () = record output "get_home" in
                resume "/xhtmlboi"
            in
            f resume effect)
      }
      (program None)
```
Both approach are tested in the patch (with and without discarding). 

I didn't take time tin the top-comment rewriting. Sorry. (But it could be nice, before the release.)
See ya.