### PR TITLE
Add PBT for Fun.Category and Fun.Arrow

### DIFF
--- a/test/preface_laws/arrow.ml
+++ b/test/preface_laws/arrow.ml
@@ -1,0 +1,54 @@
+module Laws (A : Preface_specs.ARROW) = struct
+  module C = Category.Laws (A)
+
+  let right_identity = C.right_identity
+
+  let left_identity = C.left_identity
+
+  let associativity = C.associativity
+
+  let law1 = ("arrow id = id", (fun () -> (A.arrow (fun x -> x), A.id)))
+
+  let law2 =
+    let left f g =
+      let h = Preface_core.Fun.(g % f) in
+      A.(arrow h)
+    and right f g = A.(arrow f >>> arrow g) in
+    ("arrow (g % f) = arrow f >>> arrow g", (fun f g -> (left f g, right f g)))
+  ;;
+
+  let law3 =
+    let left f = A.(fst (arrow f))
+    and right f = A.arrow (fun (x, y) -> (f x, y)) in
+    ("fst (arrow f) = arr (fst f)", (fun f -> (left f, right f)))
+  ;;
+
+  let law4 =
+    let left f g = A.(fst (f >>> g))
+    and right f g = A.(fst f >>> fst g) in
+    ("fst (f >>> g) = fst f >>> fst g", (fun f g -> (left f g, right f g)))
+  ;;
+
+  let law5 =
+    let left f g = A.(fst f >>> arrow (fun (x, y) -> (x, g y)))
+    and right f g = A.(arrow (fun (x, y) -> (x, g y)) >>> fst f) in
+    ( "fst f >>> arrow (fun (x,y) -> (x,g y)) = arrow (fun (x,y) -> (x,g y)) >>>\n\
+      \     fst f"
+    , (fun f g -> (left f g, right f g)) )
+  ;;
+
+  let law6 =
+    let left f = A.(fst f >>> arrow Stdlib.fst)
+    and right f = A.(arrow Stdlib.fst >>> f) in
+    ( "fst f >>> arrow Stdlib.fst = arrow Stdlib.fst >>> f "
+    , (fun f -> (left f, right f)) )
+  ;;
+
+  let law7 =
+    let assoc ((x, y), z) = (x, (y, z)) in
+    let left f = A.(fst (fst f) >>> arrow assoc)
+    and right f = A.(arrow assoc >>> fst f) in
+    ( "fst (fst f) >>> arrow assoc = arrow assoc >>> fst f"
+    , (fun f -> (left f, right f)) )
+  ;;
+end

--- a/test/preface_laws/arrow.mli
+++ b/test/preface_laws/arrow.mli
@@ -1,0 +1,41 @@
+(** Automatization over arrow laws *)
+
+module Laws (A : Preface_specs.ARROW) : sig
+  val right_identity : string * (('a, 'b) A.t -> ('a, 'b) A.t * ('a, 'b) A.t)
+
+  val left_identity : string * (('a, 'b) A.t -> ('a, 'b) A.t * ('a, 'b) A.t)
+
+  val associativity :
+    string
+    * (   ('a, 'b) A.t
+       -> ('c, 'a) A.t
+       -> ('d, 'c) A.t
+       -> ('d, 'b) A.t * ('d, 'b) A.t)
+
+  val law1 : string * (unit -> ('a, 'a) A.t * ('a, 'a) A.t)
+
+  val law2 : string * (('a -> 'b) -> ('b -> 'c) -> ('a, 'c) A.t * ('a, 'c) A.t)
+
+  val law3 :
+    string * (('a -> 'b) -> ('a * 'c, 'b * 'c) A.t * ('a * 'c, 'b * 'c) A.t)
+
+  val law4 :
+    string
+    * (   ('a, 'b) A.t
+       -> ('b, 'c) A.t
+       -> ('a * 'd, 'c * 'd) A.t * ('a * 'd, 'c * 'd) A.t)
+
+  val law5 :
+    string
+    * (   ('a, 'b) A.t
+       -> ('c -> 'd)
+       -> ('a * 'c, 'b * 'd) A.t * ('a * 'c, 'b * 'd) A.t)
+
+  val law6 : string * (('a, 'b) A.t -> ('a * 'c, 'b) A.t * ('a * 'd, 'b) A.t)
+
+  val law7 :
+    string
+    * (   ('a, 'b) A.t
+       -> (('a * 'c) * 'd, 'b * ('c * 'd)) A.t
+          * (('a * 'c) * 'd, 'b * ('c * 'd)) A.t)
+end

--- a/test/preface_laws/category.ml
+++ b/test/preface_laws/category.ml
@@ -1,0 +1,10 @@
+module Laws (C : Preface_specs.CATEGORY) = struct
+  let right_identity = ("f % id = f", (fun f -> (C.(f % id), f)))
+
+  let left_identity = ("id % f = f", (fun f -> (C.(id % f), f)))
+
+  let associativity =
+    ( "f % (g % h) = (f % g) % h"
+    , (fun f g h -> (C.(f % (g % h)), C.(f % g % h))) )
+  ;;
+end

--- a/test/preface_laws/category.mli
+++ b/test/preface_laws/category.mli
@@ -1,0 +1,14 @@
+(** Automatization over category laws *)
+
+module Laws (C : Preface_specs.CATEGORY) : sig
+  val right_identity : string * (('a, 'b) C.t -> ('a, 'b) C.t * ('a, 'b) C.t)
+
+  val left_identity : string * (('a, 'b) C.t -> ('a, 'b) C.t * ('a, 'b) C.t)
+
+  val associativity :
+    string
+    * (   ('a, 'b) C.t
+       -> ('c, 'a) C.t
+       -> ('d, 'c) C.t
+       -> ('d, 'b) C.t * ('d, 'b) C.t)
+end

--- a/test/preface_laws/continuation.ml
+++ b/test/preface_laws/continuation.ml
@@ -5,7 +5,9 @@ module Req = struct
 
   let observable x = Preface_qcheck.Observable.continuation x
 
-  let equal f x y = Preface_stdlib.Continuation.(f (x.run Fun.id) (y.run Fun.id))
+  let equal f x y =
+    Preface_stdlib.Continuation.(f (x.run Stdlib.Fun.id) (y.run Stdlib.Fun.id))
+  ;;
 end
 
 module Functor =

--- a/test/preface_laws/dune
+++ b/test/preface_laws/dune
@@ -3,12 +3,12 @@
  (public_name preface.laws)
  (synopsis "Encoding laws as a set of tests")
  (modules functor applicative selective monad comonad bifunctor semigroup
-   monoid alternative monad_plus alt contravariant)
+   monoid alternative monad_plus alt contravariant category arrow)
  (libraries qcheck-core qcheck-alcotest preface.core preface.specs
    preface.make preface.stdlib preface.qcheck))
 
 (test
  (name preface_laws_suite)
  (modules misc identity continuation option list nonempty_list try either
-   stream result validation validate state predicate preface_laws_suite)
- (libraries preface.qcheck preface.stdlib alcotest preface_laws))
+   stream result validation validate state fun predicate preface_laws_suite)
+ (libraries preface.qcheck preface.stdlib alcotest preface.laws))

--- a/test/preface_laws/fun.ml
+++ b/test/preface_laws/fun.ml
@@ -1,0 +1,203 @@
+module Category = Preface_laws.Category.Laws (Preface_stdlib.Fun.Category)
+module Arrow = Preface_laws.Arrow.Laws (Preface_stdlib.Fun.Arrow)
+
+let tuple_eq f g (a, b) (a', b') = f a a' && g b b'
+
+let cat_right_identity (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
+  let (name, test) = Category.right_identity in
+  Test.make ~name ~count arbitrary (fun (f', value) ->
+      let f = Fn.apply f' in
+      let (left, right) = test f in
+      P.B.equal (left value) (right value))
+;;
+
+let cat_left_identity (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
+  let (name, test) = Category.left_identity in
+  Test.make ~name ~count arbitrary (fun (f', value) ->
+      let f = Fn.apply f' in
+      let (left, right) = test f in
+      P.B.equal (left value) (right value))
+;;
+
+let cat_associativity (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary =
+    quad
+      (fun1 P.A.observable P.B.arbitrary)
+      (fun1 P.C.observable P.A.arbitrary)
+      (fun1 P.D.observable P.C.arbitrary)
+      P.D.arbitrary
+  in
+  let (name, test) = Category.associativity in
+  Test.make ~name ~count arbitrary (fun (f', g', h', value) ->
+      let f = Fn.apply f' in
+      let g = Fn.apply g' in
+      let h = Fn.apply h' in
+      let (left, right) = test f g h in
+      P.B.equal (left value) (right value))
+;;
+
+let arrow_right_identity (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
+  let (name, test) = Arrow.right_identity in
+  Test.make ~name ~count arbitrary (fun (f', value) ->
+      let f = Fn.apply f' in
+      let (left, right) = test f in
+      P.B.equal (left value) (right value))
+;;
+
+let arrow_left_identity (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
+  let (name, test) = Arrow.left_identity in
+  Test.make ~name ~count arbitrary (fun (f', value) ->
+      let f = Fn.apply f' in
+      let (left, right) = test f in
+      P.B.equal (left value) (right value))
+;;
+
+let arrow_associativity (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary =
+    quad
+      (fun1 P.A.observable P.B.arbitrary)
+      (fun1 P.C.observable P.A.arbitrary)
+      (fun1 P.D.observable P.C.arbitrary)
+      P.D.arbitrary
+  in
+  let (name, test) = Arrow.associativity in
+  Test.make ~name ~count arbitrary (fun (f', g', h', value) ->
+      let f = Fn.apply f' in
+      let g = Fn.apply g' in
+      let h = Fn.apply h' in
+      let (left, right) = test f g h in
+      P.B.equal (left value) (right value))
+;;
+
+let arrow_law1 (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary = P.A.arbitrary in
+  let (name, test) = Arrow.law1 in
+  Test.make ~name ~count arbitrary (fun value ->
+      let (left, right) = test () in
+      P.A.equal (left value) (right value))
+;;
+
+let arrow_law2 (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary =
+    triple
+      (fun1 P.A.observable P.B.arbitrary)
+      (fun1 P.B.observable P.C.arbitrary)
+      P.A.arbitrary
+  in
+  let (name, test) = Arrow.law2 in
+  Test.make ~name ~count arbitrary (fun (f', g', value) ->
+      let f = Fn.apply f' in
+      let g = Fn.apply g' in
+      let (left, right) = test f g in
+      P.C.equal (left value) (right value))
+;;
+
+let arrow_law3 (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary =
+    pair (fun1 P.A.observable P.B.arbitrary) (pair P.A.arbitrary P.C.arbitrary)
+  in
+  let (name, test) = Arrow.law3 in
+  Test.make ~name ~count arbitrary (fun (f', value) ->
+      let f = Fn.apply f' in
+      let (left, right) = test f in
+      tuple_eq P.B.equal P.C.equal (left value) (right value))
+;;
+
+let arrow_law4 (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary =
+    triple
+      (fun1 P.A.observable P.B.arbitrary)
+      (fun1 P.B.observable P.C.arbitrary)
+      (pair P.A.arbitrary P.D.arbitrary)
+  in
+  let (name, test) = Arrow.law4 in
+  Test.make ~name ~count arbitrary (fun (f', g', value) ->
+      let f = Fn.apply f' in
+      let g = Fn.apply g' in
+      let (left, right) = test f g in
+      tuple_eq P.C.equal P.D.equal (left value) (right value))
+;;
+
+let arrow_law5 (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary =
+    triple
+      (fun1 P.A.observable P.B.arbitrary)
+      (fun1 P.C.observable P.D.arbitrary)
+      (pair P.A.arbitrary P.C.arbitrary)
+  in
+  let (name, test) = Arrow.law5 in
+  Test.make ~name ~count arbitrary (fun (f', g', value) ->
+      let f = Fn.apply f' in
+      let g = Fn.apply g' in
+      let (left, right) = test f g in
+      tuple_eq P.B.equal P.D.equal (left value) (right value))
+;;
+
+let arrow_law6 (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary =
+    pair (fun1 P.A.observable P.B.arbitrary) (pair P.A.arbitrary P.C.arbitrary)
+  in
+  let (name, test) = Arrow.law6 in
+  Test.make ~name ~count arbitrary (fun (f', value) ->
+      let f = Fn.apply f' in
+      let (left, right) = test f in
+      P.B.equal (left value) (right value))
+;;
+
+let arrow_law7 (module P : Preface_qcheck.Sample.PACKAGE) count =
+  let open QCheck in
+  let arbitrary =
+    pair
+      (fun1 P.A.observable P.B.arbitrary)
+      (pair (pair P.A.arbitrary P.C.arbitrary) P.D.arbitrary)
+  in
+  let (name, test) = Arrow.law7 in
+  Test.make ~name ~count arbitrary (fun (f', value) ->
+      let f = Preface_stdlib.Fun.Arrow.arrow (Fn.apply f') in
+      let (left, right) = test f in
+      tuple_eq P.B.equal
+        (tuple_eq P.C.equal P.D.equal)
+        (left value) (right value))
+;;
+
+let cases n =
+  [
+    ( "Fun Category Laws"
+    , [
+        cat_right_identity (module Preface_qcheck.Sample.Pack1) n
+      ; cat_left_identity (module Preface_qcheck.Sample.Pack1) n
+      ; cat_associativity (module Preface_qcheck.Sample.Pack1) n
+      ]
+      |> Stdlib.List.map QCheck_alcotest.to_alcotest )
+  ; ( "Fun Arrow Laws"
+    , [
+        arrow_right_identity (module Preface_qcheck.Sample.Pack1) n
+      ; arrow_left_identity (module Preface_qcheck.Sample.Pack1) n
+      ; arrow_associativity (module Preface_qcheck.Sample.Pack1) n
+      ; arrow_law1 (module Preface_qcheck.Sample.Pack1) n
+      ; arrow_law2 (module Preface_qcheck.Sample.Pack1) n
+      ; arrow_law3 (module Preface_qcheck.Sample.Pack1) n
+      ; arrow_law4 (module Preface_qcheck.Sample.Pack1) n
+      ; arrow_law5 (module Preface_qcheck.Sample.Pack1) n
+      ; arrow_law6 (module Preface_qcheck.Sample.Pack1) n
+      ; arrow_law7 (module Preface_qcheck.Sample.Pack1) n
+      ]
+      |> Stdlib.List.map QCheck_alcotest.to_alcotest )
+  ]
+;;

--- a/test/preface_laws/fun.mli
+++ b/test/preface_laws/fun.mli
@@ -1,0 +1,1 @@
+val cases : int -> unit Alcotest.test list

--- a/test/preface_laws/predicate.mli
+++ b/test/preface_laws/predicate.mli
@@ -1,0 +1,1 @@
+val cases : int -> unit Alcotest.test list

--- a/test/preface_laws/preface_laws_suite.ml
+++ b/test/preface_laws/preface_laws_suite.ml
@@ -14,7 +14,8 @@ let run number =
     @ Stream.cases number
     @ Either.cases number
     @ State.cases number
-    @ Predicate.cases number )
+    @ Predicate.cases number
+    @ Fun.cases number )
 ;;
 
 let () = run 500


### PR DESCRIPTION
In order to provide more content related to arrow here is some PBT. 
For the same reason of Predicate, I can't using the generic approach, but having the execution of laws centralized in a module, it become relatively easy to test.
If this approach is valid, I'll give more test for other kind of Arrows.