### PR TITLE
Selective: move [branch] in core

### DIFF
--- a/lib/preface_make/free_selective.ml
+++ b/lib/preface_make/free_selective.ml
@@ -37,7 +37,7 @@ module Over_functor (F : Preface_specs.Functor.CORE) = struct
    ;;
   end
 
-  module S = Selective.Over_functor (Functor) (Core)
+  module S = Selective.Over_functor_via_select (Functor) (Core)
 
   module Transformation (Selective : Preface_specs.Selective.CORE) = struct
     type natural_transformation = { transform : 'a. 'a f -> 'a Selective.t }

--- a/lib/preface_make/selective.mli
+++ b/lib/preface_make/selective.mli
@@ -6,19 +6,33 @@
 
     Standard way to build [Selective Functor]. *)
 
-(** Incarnation of a [Selective] over an [Applicative]. *)
-module Over_applicative
+(** Incarnation of a [Selective] over an [Applicative] using [select]. *)
+module Over_applicative_via_select
     (Applicative : Preface_specs.APPLICATIVE)
     (Select : Preface_specs.Selective.CORE_WITH_SELECT
                 with type 'a t = 'a Applicative.t) :
   Preface_specs.SELECTIVE with type 'a t = 'a Select.t
 
-(** Incarnation of a [Selective] over a [Functor]. *)
-module Over_functor
+(** Incarnation of a [Selective] over an [Applicative] using branch. *)
+module Over_applicative_via_branch
+    (Applicative : Preface_specs.APPLICATIVE)
+    (Branch : Preface_specs.Selective.CORE_WITH_BRANCH
+                with type 'a t = 'a Applicative.t) :
+  Preface_specs.SELECTIVE with type 'a t = 'a Branch.t
+
+(** Incarnation of a [Selective] over a [Functor] using [select] and [pure]. *)
+module Over_functor_via_select
     (Functor : Preface_specs.Functor.CORE)
     (Select : Preface_specs.Selective.CORE_WITH_PURE_AND_SELECT
                 with type 'a t = 'a Functor.t) :
   Preface_specs.SELECTIVE with type 'a t = 'a Select.t
+
+(** Incarnation of a [Selective] over a [Functor] using [branch] and [pure]. *)
+module Over_functor_via_branch
+    (Functor : Preface_specs.Functor.CORE)
+    (Branch : Preface_specs.Selective.CORE_WITH_PURE_AND_BRANCH
+                with type 'a t = 'a Functor.t) :
+  Preface_specs.SELECTIVE with type 'a t = 'a Branch.t
 
 (** {2 Manual construction}
 
@@ -34,17 +48,31 @@ module Via
     (Syntax : Preface_specs.Selective.SYNTAX with type 'a t = 'a Core.t) :
   Preface_specs.SELECTIVE with type 'a t = 'a Core.t
 
-(** Incarnation of a [Selective.Core] over a [Functor]. *)
-module Core_over_functor
+(** Incarnation of a [Selective.Core] over a [Functor] via [select] and [pure]. *)
+module Core_over_functor_via_select
     (Functor : Preface_specs.Functor.CORE)
     (Select : Preface_specs.Selective.CORE_WITH_PURE_AND_SELECT
                 with type 'a t = 'a Functor.t) :
   Preface_specs.Selective.CORE with type 'a t = 'a Functor.t
 
-(** Incarnation of a [Selective.Core] over an [Applicative]. *)
-module Core_over_applicative
+(** Incarnation of a [Selective.Core] over a [Functor] via [branch] and [pure]. *)
+module Core_over_functor_via_branch
+    (Functor : Preface_specs.Functor.CORE)
+    (Branch : Preface_specs.Selective.CORE_WITH_PURE_AND_BRANCH
+                with type 'a t = 'a Functor.t) :
+  Preface_specs.Selective.CORE with type 'a t = 'a Functor.t
+
+(** Incarnation of a [Selective.Core] over an [Applicative] using [select]. *)
+module Core_over_applicative_via_select
     (Applicative : Preface_specs.APPLICATIVE)
     (Select : Preface_specs.Selective.CORE_WITH_SELECT
+                with type 'a t = 'a Applicative.t) :
+  Preface_specs.Selective.CORE with type 'a t = 'a Applicative.t
+
+(** Incarnation of a [Selective.Core] over an [Applicative] using [branch]. *)
+module Core_over_applicative_via_branch
+    (Applicative : Preface_specs.APPLICATIVE)
+    (Branch : Preface_specs.Selective.CORE_WITH_BRANCH
                 with type 'a t = 'a Applicative.t) :
   Preface_specs.Selective.CORE with type 'a t = 'a Applicative.t
 

--- a/lib/preface_specs/selective.mli
+++ b/lib/preface_specs/selective.mli
@@ -4,6 +4,7 @@
 
 (** {1 Structure anatomy} *)
 
+(** Standard requirement with [select]. *)
 module type CORE_WITH_SELECT = sig
   type 'a t
   (** The type held by the [Selective]. *)
@@ -13,6 +14,16 @@ module type CORE_WITH_SELECT = sig
       [Right]. *)
 end
 
+(** Standard requirement with [branch]. *)
+module type CORE_WITH_BRANCH = sig
+  type 'a t
+  (** The type held by the [Selective]. *)
+
+  val branch : ('a, 'b) Either.t t -> ('a -> 'c) t -> ('b -> 'c) t -> 'c t
+  (** [branch] is like [select]. It chooses between two effects. *)
+end
+
+(** Standard requirement including [pure] and [select]. *)
 module type CORE_WITH_PURE_AND_SELECT = sig
   include CORE_WITH_SELECT
 
@@ -20,9 +31,19 @@ module type CORE_WITH_PURE_AND_SELECT = sig
   (** Create a new ['a t]. *)
 end
 
-(** Standard requirement. *)
+(** Standard requirement including [pure] and [branch]. *)
+module type CORE_WITH_PURE_AND_BRANCH = sig
+  include CORE_WITH_BRANCH
+
+  val pure : 'a -> 'a t
+  (** Create a new ['a t]. *)
+end
+
+(** Standard requirement including Applicative requirements. *)
 module type CORE = sig
   include CORE_WITH_SELECT
+
+  include CORE_WITH_BRANCH with type 'a t := 'a t
 
   include Applicative.CORE with type 'a t := 'a t
   (** Each [Selective] is also an [Applicative]. *)
@@ -35,9 +56,6 @@ module type OPERATION = sig
 
   include Applicative.OPERATION with type 'a t := 'a t
   (** Each [Selective] is also an [Applicative]. *)
-
-  val branch : ('a, 'b) Either.t t -> ('a -> 'c) t -> ('b -> 'c) t -> 'c t
-  (** [branch] is like [select]. It chooses between two effects. *)
 
   val if_ : bool t -> 'a t -> 'a t -> 'a t
   (** Same of [branch] but using a [Boolean] as disjunction. *)

--- a/lib/preface_stdlib/approximation.ml
+++ b/lib/preface_stdlib/approximation.ml
@@ -10,7 +10,7 @@ module Over (M : Preface_specs.MONOID) = struct
   end)
 
   module Selective =
-    Preface_make.Selective.Over_applicative
+    Preface_make.Selective.Over_applicative_via_select
       (Applicative)
       (struct
         type nonrec 'a t = 'a t
@@ -31,7 +31,7 @@ module Under (M : Preface_specs.MONOID) = struct
   end)
 
   module Selective =
-    Preface_make.Selective.Over_applicative
+    Preface_make.Selective.Over_applicative_via_select
       (Applicative)
       (struct
         type nonrec 'a t = 'a t

--- a/lib/preface_stdlib/identity.ml
+++ b/lib/preface_stdlib/identity.ml
@@ -27,7 +27,7 @@ module Monad = Preface_make.Monad.Via_bind (struct
 end)
 
 module Selective =
-  Preface_make.Selective.Over_applicative
+  Preface_make.Selective.Over_applicative_via_select
     (Applicative)
     (Preface_make.Selective.Select_from_monad (Monad))
 

--- a/lib/preface_stdlib/list.ml
+++ b/lib/preface_stdlib/list.ml
@@ -96,7 +96,7 @@ module Monad_traversable (M : Preface_specs.MONAD) =
 module Monad =
   Preface_make.Traversable.Join_with_monad (Monad_plus) (Monad_traversable)
 module Selective =
-  Preface_make.Selective.Over_applicative
+  Preface_make.Selective.Over_applicative_via_select
     (Applicative)
     (Preface_make.Selective.Select_from_monad (Monad))
 

--- a/lib/preface_stdlib/nonempty_list.ml
+++ b/lib/preface_stdlib/nonempty_list.ml
@@ -93,7 +93,7 @@ module Monad_traversable (M : Preface_specs.MONAD) =
 module Monad =
   Preface_make.Traversable.Join_with_monad (Monad_internal) (Monad_traversable)
 module Selective =
-  Preface_make.Selective.Over_applicative
+  Preface_make.Selective.Over_applicative_via_select
     (Applicative)
     (Preface_make.Selective.Select_from_monad (Monad))
 

--- a/lib/preface_stdlib/validation.ml
+++ b/lib/preface_stdlib/validation.ml
@@ -60,7 +60,7 @@ module Selective (Errors : Preface_specs.SEMIGROUP) = struct
   module A = Applicative (Errors)
 
   module S =
-    Preface_make.Selective.Over_applicative
+    Preface_make.Selective.Over_applicative_via_select
       (A)
       (struct
         type nonrec 'a t = ('a, Errors.t) t


### PR DESCRIPTION
As mentioned by @snowleopard (feel free to say if you don't want be ping anymore) here: https://github.com/snowleopard/selective/pull/30 `select` can be express via `branch` (and vice versa). So this PR move `branch` into `Selective.CORE` and allows to use select path or branch path for Selective incarnation.