### PR TITLE
Rexport sublibs (specs/make/stdlib) for aliasing

### DIFF
--- a/lib/preface_make/dune
+++ b/lib/preface_make/dune
@@ -1,4 +1,4 @@
 (library
  (name preface_make)
- (package preface)
- (libraries either preface_core preface_specs))
+ (public_name preface.make)
+ (libraries either preface_core preface.specs))

--- a/lib/preface_specs/dune
+++ b/lib/preface_specs/dune
@@ -1,6 +1,6 @@
 (library
  (name preface_specs)
- (package preface)
+ (public_name preface.specs)
  (modules_without_implementation
   preface_specs
   types

--- a/lib/preface_stdlib/dune
+++ b/lib/preface_stdlib/dune
@@ -1,4 +1,4 @@
 (library
  (name preface_stdlib)
- (package preface)
- (libraries either preface_core preface_specs preface_make))
+ (public_name preface.stdlib)
+ (libraries either preface_core preface.specs preface.make))


### PR DESCRIPTION
Having private modules fit not very well with aliasing, so in order to no block Wordpress´s developpement, I reintroduce preface.specs, preface.stdlib and preface.make. 