### PR TITLE
Move natural transformation into dedidacted sig

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-version:
+          - 4.12.0
           - 4.11.0
           - 4.10.1
           - 4.09.1

--- a/lib/preface_specs/free_applicative.mli
+++ b/lib/preface_specs/free_applicative.mli
@@ -18,6 +18,40 @@
 
 (** {1 Structure anatomy} *)
 
+(** The natural transformation for [Free Applicative] to [Applicative]. *)
+module type TO_APPLICATIVE = sig
+  type 'a t
+  (** The type held by the [Free applicative]. *)
+
+  type 'a f
+  (** The type held by the {!module:Preface_specs.Functor}. *)
+
+  type 'a applicative
+  (** The type held by the [Applicative]. *)
+
+  type natural_transformation = { transform : 'a. 'a f -> 'a applicative }
+
+  val run : natural_transformation -> 'a t -> 'a applicative
+  (** Run the natural transformation over the [Free applicative]. *)
+end
+
+(** The natural transformation for [Free Applicative] to [Monoid]. *)
+module type TO_MONOID = sig
+  type 'a t
+  (** The type held by the [Free applicative]. *)
+
+  type 'a f
+  (** The type held by the {!module:Preface_specs.Functor}. *)
+
+  type monoid
+  (** The type held by the [Monoid]. *)
+
+  type natural_transformation = { transform : 'a. 'a f -> monoid }
+
+  val run : natural_transformation -> 'a t -> monoid
+  (** Run the natural transformation over the [Free applicative]. *)
+end
+
 (** The [Free applicative] API without the {!module:Preface_specs.Applicative}
     API. *)
 module type CORE = sig
@@ -35,21 +69,19 @@ module type CORE = sig
 
   (** The natural transformation from a [Free applicative] to an other
       {!module:Preface_specs.Applicative}. *)
-  module To_applicative (Applicative : Applicative.CORE) : sig
-    type natural_transformation = { transform : 'a. 'a f -> 'a Applicative.t }
-
-    val run : natural_transformation -> 'a t -> 'a Applicative.t
-    (** Run the natural transformation over the [Free applicative]. *)
-  end
+  module To_applicative (Applicative : Applicative.CORE) :
+    TO_APPLICATIVE
+      with type 'a t := 'a t
+       and type 'a f := 'a f
+       and type 'a applicative := 'a Applicative.t
 
   (** The natural transformation from a [Free applicative] to a
       {!module:Preface_specs.Monoid}. *)
-  module To_monoid (Monoid : Monoid.CORE) : sig
-    type natural_transformation = { transform : 'a. 'a f -> Monoid.t }
-
-    val run : natural_transformation -> 'a t -> Monoid.t
-    (** Run the natural transformation over the [Free applicative]. *)
-  end
+  module To_monoid (Monoid : Monoid.CORE) :
+    TO_MONOID
+      with type 'a t := 'a t
+       and type 'a f := 'a f
+       and type monoid := Monoid.t
 end
 
 (** {1 Complete API} *)

--- a/lib/preface_specs/free_selective.mli
+++ b/lib/preface_specs/free_selective.mli
@@ -18,6 +18,40 @@
 
 (** {1 Structure anatomy} *)
 
+(** The natural transformation for [Free Selective] to [Selective]. *)
+module type TO_SELECTIVE = sig
+  type 'a t
+  (** The type held by the [Free Selective]. *)
+
+  type 'a f
+  (** The type held by the {!module:Preface_specs.Functor}. *)
+
+  type 'a selective
+  (** The type held by the [Selective]. *)
+
+  type natural_transformation = { transform : 'a. 'a f -> 'a selective }
+
+  val run : natural_transformation -> 'a t -> 'a selective
+  (** Run the natural transformation over the [Free selective]. *)
+end
+
+(** The natural transformation for [Free Selective] to [Monoid]. *)
+module type TO_MONOID = sig
+  type 'a t
+  (** The type held by the [Free selective]. *)
+
+  type 'a f
+  (** The type held by the {!module:Preface_specs.Functor}. *)
+
+  type monoid
+  (** The type held by the [Monoid]. *)
+
+  type natural_transformation = { transform : 'a. 'a f -> monoid }
+
+  val run : natural_transformation -> 'a t -> monoid
+  (** Run the natural transformation over the [Free applicative]. *)
+end
+
 (** The [Free selective] API without the {!module:Preface_specs.Selective} API. *)
 module type CORE = sig
   type 'a f
@@ -35,21 +69,19 @@ module type CORE = sig
 
   (** The natural transformation from a [Free selective] to an other
       {!module:Preface_specs.Selective}. *)
-  module To_selective (Selective : Selective.CORE) : sig
-    type natural_transformation = { transform : 'a. 'a f -> 'a Selective.t }
-
-    val run : natural_transformation -> 'a t -> 'a Selective.t
-    (** Run the natural transformation over the [Free selective]. *)
-  end
+  module To_selective (Selective : Selective.CORE) :
+    TO_SELECTIVE
+      with type 'a t := 'a t
+       and type 'a f := 'a f
+       and type 'a selective := 'a Selective.t
 
   (** The natural transformation from a [Free selective] to a
       {!module:Preface_specs.Monoid}. *)
-  module To_monoid (Monoid : Monoid.CORE) : sig
-    type natural_transformation = { transform : 'a. 'a f -> Monoid.t }
-
-    val run : natural_transformation -> 'a t -> Monoid.t
-    (** Run the natural transformation over the [Free selective]. *)
-  end
+  module To_monoid (Monoid : Monoid.CORE) :
+    TO_MONOID
+      with type 'a t := 'a t
+       and type 'a f := 'a f
+       and type monoid := Monoid.t
 end
 
 (** {1 Complete API} *)


### PR DESCRIPTION
The natural transformation from Free (Applicative or Selective) was inlined into the signature so it was difficult to create a specialized version of Free using Include (ie: Bladwyzer.Env.t) so I put the natural transformation outside of the core and usingdestructive substitution itis mainly transparent at the user level.

Here is an example of the trouble I can have without this separation: 

```ocaml
type 'a field =
  { valid : string option -> 'a Preface.Validate.t
  ; label : string
  }

include Preface.Specs.FREE_APPLICATIVE with type 'a f = 'a field

(** Here, I need to apply the functor in the signature and I don't like it *)
module Run : (module type of To_applicative (Preface.Validate.Applicative))
```

This PR also adds `4.12.0` in the test matrix