### PR TITLE
Move lift2 into applicative core

### DIFF
--- a/lib/preface_make/alternative.ml
+++ b/lib/preface_make/alternative.ml
@@ -17,6 +17,15 @@ module Core_via_apply (Req : Preface_specs.Alternative.WITH_APPLY) :
   let neutral = Req.neutral
 end
 
+module Core_via_lift2 (Req : Preface_specs.Alternative.WITH_LIFT2) :
+  Preface_specs.Alternative.CORE with type 'a t = 'a Req.t = struct
+  include Applicative.Core_via_lift2 (Req)
+
+  let combine = Req.combine
+
+  let neutral = Req.neutral
+end
+
 let reduce' combine neutral list = List.fold_left combine neutral list
 
 module Operation (Core : Preface_specs.Alternative.CORE) :
@@ -69,6 +78,18 @@ end
 module Via_apply (Req : Preface_specs.Alternative.WITH_APPLY) :
   Preface_specs.ALTERNATIVE with type 'a t = 'a Req.t = struct
   module Core = Core_via_apply (Req)
+  module Operation = Operation (Core)
+  module Syntax = Syntax (Core)
+  module Infix = Infix (Core) (Operation)
+  include Core
+  include Operation
+  include Syntax
+  include Infix
+end
+
+module Via_lift2 (Req : Preface_specs.Alternative.WITH_LIFT2) :
+  Preface_specs.ALTERNATIVE with type 'a t = 'a Req.t = struct
+  module Core = Core_via_lift2 (Req)
   module Operation = Operation (Core)
   module Syntax = Syntax (Core)
   module Infix = Infix (Core) (Operation)

--- a/lib/preface_make/alternative.mli
+++ b/lib/preface_make/alternative.mli
@@ -25,6 +25,17 @@ module Via_map_and_product
     (Req : Preface_specs.Alternative.WITH_MAP_AND_PRODUCT) :
   Preface_specs.ALTERNATIVE with type 'a t = 'a Req.t
 
+(** {2 Using pure, lift2, neutral and combine}
+
+    Build a {!module-type:Preface_specs.ALTERNATIVE} using
+    {!module-type:Preface_specs.Alternative.WITH_LIFT2}.
+
+    Other standard method, using the minimal definition of an alt to derive its
+    full API. *)
+
+module Via_lift2 (Req : Preface_specs.Alternative.WITH_LIFT2) :
+  Preface_specs.ALTERNATIVE with type 'a t = 'a Req.t
+
 (** {2 Over an applicative}
 
     Build a {!module-type:Preface_specs.ALTERNATIVE} over an
@@ -93,6 +104,9 @@ module Core_via_map_and_product
   Preface_specs.Alternative.CORE with type 'a t = 'a Req.t
 
 module Core_via_apply (Req : Preface_specs.Alternative.WITH_APPLY) :
+  Preface_specs.Alternative.CORE with type 'a t = 'a Req.t
+
+module Core_via_lift2 (Req : Preface_specs.Alternative.WITH_LIFT2) :
   Preface_specs.Alternative.CORE with type 'a t = 'a Req.t
 
 (** {2 Deriving Operation} *)

--- a/lib/preface_make/applicative.mli
+++ b/lib/preface_make/applicative.mli
@@ -25,6 +25,17 @@ module Via_map_and_product
     (Req : Preface_specs.Applicative.WITH_MAP_AND_PRODUCT) :
   Preface_specs.APPLICATIVE with type 'a t = 'a Req.t
 
+(** {2 Using pure and lift2}
+
+    Build a {!module-type:Preface_specs.APPLICATIVE} using
+    {!module-type:Preface_specs.Applicative.WITH_LIFT2}.
+
+    Other standard method, using the minimal definition of an alt to derive its
+    full API. *)
+
+module Via_lift2 (Req : Preface_specs.Applicative.WITH_LIFT2) :
+  Preface_specs.APPLICATIVE with type 'a t = 'a Req.t
+
 (** {1 Applicative Algebra}
 
     Construction of {!module-type:Preface_specs.APPLICATIVE} by combining them. *)
@@ -109,6 +120,9 @@ module Core_via_map_and_product
   Preface_specs.Applicative.CORE with type 'a t = 'a Req.t
 
 module Core_via_apply (Req : Preface_specs.Applicative.WITH_APPLY) :
+  Preface_specs.Applicative.CORE with type 'a t = 'a Req.t
+
+module Core_via_lift2 (Req : Preface_specs.Applicative.WITH_LIFT2) :
   Preface_specs.Applicative.CORE with type 'a t = 'a Req.t
 
 (** {2 Deriving Operation} *)

--- a/lib/preface_make/free_applicative.ml
+++ b/lib/preface_make/free_applicative.ml
@@ -35,9 +35,9 @@ module Over_functor (F : Preface_specs.Functor.CORE) :
         Apply (gs, x)
    ;;
 
-   let product a b = apply (apply (Pure (fun x y -> (x, y))) a) b
+    let product a b = apply (apply (Pure (fun x y -> (x, y))) a) b
 
-   let lift2 f x y = apply (map f x) y
+    let lift2 f x y = apply (map f x) y
   end
 
   module Operation = Applicative.Operation (Core)

--- a/lib/preface_make/free_applicative.ml
+++ b/lib/preface_make/free_applicative.ml
@@ -35,7 +35,9 @@ module Over_functor (F : Preface_specs.Functor.CORE) :
         Apply (gs, x)
    ;;
 
-    let product a b = apply (apply (Pure (fun x y -> (x, y))) a) b
+   let product a b = apply (apply (Pure (fun x y -> (x, y))) a) b
+
+   let lift2 f x y = apply (map f x) y
   end
 
   module Operation = Applicative.Operation (Core)

--- a/lib/preface_specs/alternative.mli
+++ b/lib/preface_specs/alternative.mli
@@ -39,6 +39,13 @@ module type WITH_APPLY = sig
   include WITH_NEUTRAL_AND_COMBINE with type 'a t := 'a t
 end
 
+(** Minimal definition using [neutral], [combine], [pure] and [lift2]. *)
+module type WITH_LIFT2 = sig
+  include Applicative.WITH_LIFT2
+
+  include WITH_NEUTRAL_AND_COMBINE with type 'a t := 'a t
+end
+
 (** {1 Structure anatomy} *)
 
 (** Basis operations. *)

--- a/lib/preface_specs/applicative.mli
+++ b/lib/preface_specs/applicative.mli
@@ -47,6 +47,18 @@ module type WITH_APPLY = sig
   (** [Applicative] functor of [('a -> 'b) t] over ['a t] to ['b t]. *)
 end
 
+(** Minimal interface using [lift2]. *)
+module type WITH_LIFT2 = sig
+  type 'a t
+  (** The type held by the [Applicative]. *)
+
+  val pure : 'a -> 'a t
+  (** Lift a value from ['a] into a new ['a t]. *)
+
+  val lift2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+  (** Mapping over from ['a] and ['b] to ['c] over ['a t] and ['b t] to ['c t]. *)
+end
+
 (** {1 Structure anatomy} *)
 
 (** Basis operations. *)
@@ -55,6 +67,9 @@ module type CORE = sig
   (** @inline *)
 
   include WITH_MAP_AND_PRODUCT with type 'a t := 'a t
+  (** @inline *)
+
+  include WITH_LIFT2 with type 'a t := 'a t
   (** @inline *)
 end
 
@@ -65,9 +80,6 @@ module type OPERATION = sig
 
   val lift : ('a -> 'b) -> 'a t -> 'b t
   (** Mapping over from ['a] to ['b] over ['a t] to ['b t]. *)
-
-  val lift2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
-  (** Mapping over from ['a] and ['b] to ['c] over ['a t] and ['b t] to ['c t]. *)
 
   val lift3 : ('a -> 'b -> 'c -> 'd) -> 'a t -> 'b t -> 'c t -> 'd t
   (** Mapping over from ['a] and ['b] and ['c] to ['d] over ['a t] and ['b t]


### PR DESCRIPTION
`lift2` can define `apply` so it should be present in `Applicative.Core`.