### PR TITLE
Use absolute image link for remote documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## dev (Unreleased)
 
+- Use absolute URLs for image in documentation (in order to fit with the new version of OCaml.org) [**@xvw**](https://github.com/xvw)
 - Add `Selective` for `Free monad` and `Freer monad` [**@xvw**](https://github.com/xvw)
 
 ## v0.1.0 (August 2021)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ can see, the diagram is heavily inspired by the
 [Haskell](https://haskell.org) community's
 [Typeclassopedia](https://wiki.haskell.org/Typeclassopedia).
 
-<p align="center"><img src=".github/figures/specs.svg" alt="typeclassopedia"></p>
+<p align="center"><img src="https://ocaml-preface.github.io/images/specs.svg" alt="typeclassopedia"></p>
 
 Obviously, the set of useful abstractions is still far from being
 present in Preface. One can deplore the absence, for example, of
@@ -220,7 +220,7 @@ but builds the whole abstraction.
 Here is an example of the canonical flow of concretisation of an
 abstraction:
 
-<p align="center"><img src=".github/figures/cut.svg" alt="module hierarchy"></p>
+<p align="center"><img src="https://ocaml-preface.github.io/images/cut.svg" alt="module hierarchy"></p>
 
 Although it is likely that the use of the _Happy Path_ covers a very
 large part of the use cases and that it is not necessary to concretise

--- a/lib/preface/preface.ml
+++ b/lib/preface/preface.ml
@@ -166,7 +166,7 @@ module Make = Preface_make
       <center>
         <img
           style="width:75%; margin: 8%;"
-          src="../../images/cut.svg"
+          src="https://ocaml-preface.github.io/images/cut.svg"
           alt="Module cutting"
         >
       </center> %} *)

--- a/lib/preface_specs/preface_specs.mli
+++ b/lib/preface_specs/preface_specs.mli
@@ -5,9 +5,9 @@
 
     {%html:
       <center>
-        <a href="../../images/specs.svg"><img
+        <a href="https://ocaml-preface.github.io/images/specs.svg"><img
           style="width:90%; margin: 10% 5%;"
-          src="../../images/specs.svg"
+          src="https://ocaml-preface.github.io/images/specs.svg"
           alt="Abstraction hierarchy"
         ></a>
       </center>%} *)


### PR DESCRIPTION
Image was "relative" which is not straightforward for remote documentation provider (like in https://v3.ocaml.org/p/preface/0.1.0/doc/Preface/index.html) So I take the liberty to use absolute URI. 