### PR TITLE
Remove early destructive substitution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## dev (Unreleased)
 
+- Removing early destructive substitution [**@xhtmlboi**](https://github.com/xhtmlboi)
 - Add `Semigroupoid` [**@d-plaindoux**](https://github.com/d-plaindoux)
 - Add `Freer Selective` [**@gr-im**](https://github.com/gr-im)
 - Add `Invariant` (Functor) (and some instance) [**@gr-im**](https://github.com/gr-im)

--- a/lib/preface_make/alternative.ml
+++ b/lib/preface_make/alternative.ml
@@ -115,17 +115,11 @@ module Over_applicative
       let reduce list = reduce' Req.combine Req.neutral list
     end)
     (struct
-      type 'a t = 'a Applicative.t
-
       include Applicative.Infix
 
       let ( <|> ) = Req.combine
     end)
-    (struct
-      type 'a t = 'a Applicative.t
-
-      include Applicative.Syntax
-    end)
+    (Applicative.Syntax)
 
 module Composition
     (F : Preface_specs.ALTERNATIVE)

--- a/lib/preface_make/monad_plus.ml
+++ b/lib/preface_make/monad_plus.ml
@@ -134,17 +134,11 @@ module Over_monad
     end)
     (Operation_over_monad (Monad) (Req))
     (struct
-      type 'a t = 'a Monad.t
-
       include Monad.Infix
 
       let ( <|> ) = Req.combine
     end)
-    (struct
-      type 'a t = 'a Monad.t
-
-      include Monad.Syntax
-    end)
+    (Monad.Syntax)
 
 module Over_monad_and_alternative
     (Monad : Preface_specs.MONAD)

--- a/lib/preface_specs/alt.mli
+++ b/lib/preface_specs/alt.mli
@@ -84,7 +84,7 @@ module type API = sig
 
   (** {1 Infix operators} *)
 
-  module Infix : INFIX with type 'a t := 'a t
+  module Infix : INFIX with type 'a t = 'a t
 
   include INFIX with type 'a t := 'a t
   (** @inline *)

--- a/lib/preface_specs/alternative.mli
+++ b/lib/preface_specs/alternative.mli
@@ -109,16 +109,16 @@ module type API = sig
 
   (** {1 Infix operators} *)
 
-  module Infix : INFIX with type 'a t := 'a t
+  module Infix : INFIX with type 'a t = 'a t
 
-  include module type of Infix
+  include INFIX with type 'a t := 'a t
   (** @inline *)
 
   (** {1 Syntax} *)
 
-  module Syntax : SYNTAX with type 'a t := 'a t
+  module Syntax : SYNTAX with type 'a t = 'a t
 
-  include module type of Syntax
+  include SYNTAX with type 'a t := 'a t
   (** @inline *)
 end
 

--- a/lib/preface_specs/applicative.mli
+++ b/lib/preface_specs/applicative.mli
@@ -141,16 +141,16 @@ module type API = sig
 
   (** {1 Infix operators} *)
 
-  module Infix : INFIX with type 'a t := 'a t
+  module Infix : INFIX with type 'a t = 'a t
 
-  include module type of Infix
+  include INFIX with type 'a t := 'a t
   (** @inline *)
 
   (** {1 Syntax} *)
 
-  module Syntax : SYNTAX with type 'a t := 'a t
+  module Syntax : SYNTAX with type 'a t = 'a t
 
-  include module type of Syntax
+  include SYNTAX with type 'a t := 'a t
   (** @inline *)
 end
 

--- a/lib/preface_specs/comonad.mli
+++ b/lib/preface_specs/comonad.mli
@@ -86,7 +86,8 @@ module type OPERATION = sig
       and ['c t] to ['d t]. *)
 
   val compose_right_to_left : ('b t -> 'c) -> ('a t -> 'b) -> 'a t -> 'c
-  (** Composing co-monadic functions using Co-Kleisli Arrow (from right to left). *)
+  (** Composing co-monadic functions using Co-Kleisli Arrow (from right to
+      left). *)
 
   include Functor.OPERATION with type 'a t := 'a t
   (** @inline *)
@@ -158,16 +159,16 @@ module type API = sig
 
   (** {1 Infix operators} *)
 
-  module Infix : INFIX with type 'a t := 'a t
+  module Infix : INFIX with type 'a t = 'a t
 
-  include module type of Infix
+  include INFIX with type 'a t := 'a t
   (** @inline *)
 
   (** {1 Syntax} *)
 
-  module Syntax : SYNTAX with type 'a t := 'a t
+  module Syntax : SYNTAX with type 'a t = 'a t
 
-  include module type of Syntax
+  include SYNTAX with type 'a t := 'a t
   (** @inline *)
 end
 

--- a/lib/preface_specs/contravariant.mli
+++ b/lib/preface_specs/contravariant.mli
@@ -71,9 +71,9 @@ module type API = sig
 
   (** {1 Infix operators} *)
 
-  module Infix : INFIX with type 'a t := 'a t
+  module Infix : INFIX with type 'a t = 'a t
 
-  include module type of Infix
+  include INFIX with type 'a t := 'a t
   (** @inline *)
 end
 

--- a/lib/preface_specs/divisible.mli
+++ b/lib/preface_specs/divisible.mli
@@ -65,9 +65,9 @@ module type API = sig
 
   (** {1 Infix operators} *)
 
-  module Infix : INFIX with type 'a t := 'a t
+  module Infix : INFIX with type 'a t = 'a t
 
-  include module type of Infix
+  include INFIX with type 'a t := 'a t
   (** @inline *)
 end
 

--- a/lib/preface_specs/functor.mli
+++ b/lib/preface_specs/functor.mli
@@ -78,9 +78,9 @@ module type API = sig
 
   (** {1 Infix operators} *)
 
-  module Infix : INFIX with type 'a t := 'a t
+  module Infix : INFIX with type 'a t = 'a t
 
-  include module type of Infix
+  include INFIX with type 'a t := 'a t
   (** @inline *)
 end
 

--- a/lib/preface_specs/monad.mli
+++ b/lib/preface_specs/monad.mli
@@ -168,16 +168,16 @@ module type API = sig
 
   (** {1 Infix operators} *)
 
-  module Infix : INFIX with type 'a t := 'a t
+  module Infix : INFIX with type 'a t = 'a t
 
-  include module type of Infix
+  include INFIX with type 'a t := 'a t
   (** @inline *)
 
   (** {1 Syntax} *)
 
-  module Syntax : SYNTAX with type 'a t := 'a t
+  module Syntax : SYNTAX with type 'a t = 'a t
 
-  include module type of Syntax
+  include SYNTAX with type 'a t := 'a t
   (** @inline *)
 end
 

--- a/lib/preface_specs/monad_plus.mli
+++ b/lib/preface_specs/monad_plus.mli
@@ -97,16 +97,16 @@ module type API = sig
 
   (** {1 Infix operators} *)
 
-  module Infix : INFIX with type 'a t := 'a t
+  module Infix : INFIX with type 'a t = 'a t
 
-  include module type of Infix
+  include INFIX with type 'a t := 'a t
   (** @inline *)
 
   (** {1 Syntax} *)
 
-  module Syntax : SYNTAX with type 'a t := 'a t
+  module Syntax : SYNTAX with type 'a t = 'a t
 
-  include module type of Syntax
+  include SYNTAX with type 'a t := 'a t
   (** @inline *)
 end
 

--- a/lib/preface_specs/selective.mli
+++ b/lib/preface_specs/selective.mli
@@ -159,16 +159,16 @@ module type API = sig
 
   (** {1 Infix operators} *)
 
-  module Infix : INFIX with type 'a t := 'a t
+  module Infix : INFIX with type 'a t = 'a t
 
-  include module type of Infix
+  include INFIX with type 'a t := 'a t
   (** @inline *)
 
   (** {1 Syntax} *)
 
-  module Syntax : SYNTAX with type 'a t := 'a t
+  module Syntax : SYNTAX with type 'a t = 'a t
 
-  include module type of Syntax
+  include SYNTAX with type 'a t := 'a t
   (** @inline *)
 end
 


### PR DESCRIPTION
From my point of view, the destructive substitution appeared too early. At the level of the declaration of an Infix or Syntax module, whereas it should appear at the level of the inclusion.