### PR TITLE
Rename `times` into `times_nel` and add `times`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## dev (Unreleased)
-
+ 
+- Rename `times` to `times_to_nel` for _semigroup-ish_ and add `times` for _monoid-ish_ [**@xvw**](https://github.com/xvw)
 - Add `Decidable` (Contravariant analogue for `Alternative`) and add some missing infixes operators for `Divisible` [**@gr-im**](https://github.com/gr-im)
 - Removing early destructive substitution [**@xhtmlboi**](https://github.com/xhtmlboi)
 - Add `Semigroupoid` [**@d-plaindoux**](https://github.com/d-plaindoux)

--- a/lib/preface_core/monoid.ml
+++ b/lib/preface_core/monoid.ml
@@ -1,9 +1,13 @@
-let times combine n x =
+let times_nel combine n x =
   if n > 0
   then
     let result = Array.make (pred n) x |> Array.fold_left combine x in
     Some result
   else None
+;;
+
+let times combine neutral n x =
+  if n >= 0 then Array.make n x |> Array.fold_left combine neutral else neutral
 ;;
 
 let reduce_nel combine list = Nonempty_list.reduce combine list

--- a/lib/preface_core/monoid.mli
+++ b/lib/preface_core/monoid.mli
@@ -1,8 +1,12 @@
 (** A generic monoid. *)
 
-val times : ('a -> 'a -> 'a) -> int -> 'a -> 'a option
-(** [times combine n x] apply [combine] on [x] [n] times. If [n] is lower than
-    [1] the function will returns [None] . *)
+val times_nel : ('a -> 'a -> 'a) -> int -> 'a -> 'a option
+(** [times_nel combine n x] apply [combine] on [x] [n] times. If [n] is lower
+    than [1] the function will returns [None] . *)
+
+val times : ('a -> 'a -> 'a) -> 'a -> int -> 'a -> 'a
+(** [times combine neutral n x] apply [combine] on [x] [n] times. If [n] is
+    lower than [1] the function will returns [neutral] . *)
 
 val reduce_nel : ('a -> 'a -> 'a) -> 'a Nonempty_list.t -> 'a
 (** [reduce_nel combine list] Reduce a [Nonempty_list.t] using [combine]. *)

--- a/lib/preface_make/alt.ml
+++ b/lib/preface_make/alt.ml
@@ -9,7 +9,7 @@ end
 module Core (Req : Preface_specs.Alt.WITH_COMBINE_AND_MAP) = Req
 
 module Times_and_reduce_nel (Core : Preface_specs.Alt.WITH_COMBINE) = struct
-  let times n x = Preface_core.Monoid.times Core.combine n x
+  let times_nel n x = Preface_core.Monoid.times_nel Core.combine n x
 
   let reduce_nel list = Preface_core.Monoid.reduce_nel Core.combine list
 end

--- a/lib/preface_make/alternative.ml
+++ b/lib/preface_make/alternative.ml
@@ -30,6 +30,8 @@ module Operation (Core : Preface_specs.Alternative.CORE) = struct
   include Applicative.Operation (Core)
   include Alt.Operation (Core)
 
+  let times n x = Preface_core.Monoid.times Core.combine Core.neutral n x
+
   let reduce list = reduce' Core.combine Core.neutral list
 end
 
@@ -111,6 +113,8 @@ module Over_applicative
       end)
 
       include Applicative
+
+      let times n x = Preface_core.Monoid.times Req.combine Req.neutral n x
 
       let reduce list = reduce' Req.combine Req.neutral list
     end)

--- a/lib/preface_make/arrow_alt.ml
+++ b/lib/preface_make/arrow_alt.ml
@@ -25,7 +25,7 @@ module Operation_over_category
 struct
   include Arrow.Operation_over_category (Category) (Core)
 
-  let times n x = Preface_core.Monoid.times Core.combine n x
+  let times_nel n x = Preface_core.Monoid.times_nel Core.combine n x
 
   let reduce_nel list = Preface_core.Monoid.reduce_nel Core.combine list
 end

--- a/lib/preface_make/arrow_plus.ml
+++ b/lib/preface_make/arrow_plus.ml
@@ -29,9 +29,11 @@ module Operation_over_category
 struct
   include Arrow.Operation_over_category (Category) (Core)
 
-  let times n x = Preface_core.Monoid.times Core.combine n x
+  let times_nel n x = Preface_core.Monoid.times_nel Core.combine n x
 
   let reduce_nel list = Preface_core.Monoid.reduce_nel Core.combine list
+
+  let times n x = Preface_core.Monoid.times Core.combine Core.neutral n x
 
   let reduce list = Preface_core.Monoid.reduce Core.combine Core.neutral list
 end

--- a/lib/preface_make/clown.mli
+++ b/lib/preface_make/clown.mli
@@ -1,5 +1,6 @@
 (** [Clown] can produces [Bifunctor] or [Profunctor] using a [Functor] (or a
-    [Contravariant]) on the first argument of the [Bi/Profunctor] as described in
+    [Contravariant]) on the first argument of the [Bi/Profunctor] as described
+    in
     {{:https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.475.6134&rep=rep1&type=pdf}
     Clowns to the Left, Jokers to the Right (Functional Pearl)}*)
 

--- a/lib/preface_make/monad_plus.ml
+++ b/lib/preface_make/monad_plus.ml
@@ -33,6 +33,8 @@ module Operation (Core : Preface_specs.Monad_plus.CORE) = struct
   include Monad.Operation (Core)
   include Alt.Operation (Core)
 
+  let times n x = Preface_core.Monoid.times Core.combine Core.neutral n x
+
   let reduce list = Preface_core.Monoid.reduce Core.combine Core.neutral list
 
   let filter predicate m =
@@ -51,6 +53,8 @@ struct
     include Monad
     include Req
   end)
+
+  let times n x = Preface_core.Monoid.times Req.combine Req.neutral n x
 
   let reduce list = Preface_core.Monoid.reduce Req.combine Req.neutral list
 

--- a/lib/preface_make/monoid.ml
+++ b/lib/preface_make/monoid.ml
@@ -12,6 +12,8 @@ module Core (Req : Preface_specs.Monoid.WITH_NEUTRAL_AND_COMBINE) = Req
 module Operation (Core : Preface_specs.Monoid.CORE) = struct
   include Semigroup.Operation (Core)
 
+  let times n x = Preface_core.Monoid.times Core.combine Core.neutral n x
+
   let reduce list = Preface_core.Monoid.reduce Core.combine Core.neutral list
 end
 

--- a/lib/preface_make/semigroup.ml
+++ b/lib/preface_make/semigroup.ml
@@ -3,7 +3,7 @@ module Core (Req : Preface_specs.Semigroup.WITH_COMBINE) = Req
 module Operation (Core : Preface_specs.Semigroup.CORE) = struct
   type t = Core.t
 
-  let times n x = Preface_core.Monoid.times Core.combine n x
+  let times_nel n x = Preface_core.Monoid.times_nel Core.combine n x
 
   let reduce_nel list = Preface_core.Monoid.reduce_nel Core.combine list
 end

--- a/lib/preface_specs/alt.mli
+++ b/lib/preface_specs/alt.mli
@@ -42,9 +42,9 @@ module type OPERATION = sig
   type 'a t
   (** A type ['a t] held by the [Alt]. *)
 
-  val times : int -> 'a t -> 'a t option
-  (** [times n x] apply [combine] on [x] [n] times. If [n] is lower than [1] the
-      function will returns [None]. *)
+  val times_nel : int -> 'a t -> 'a t option
+  (** [times_nel n x] apply [combine] on [x] [n] times. If [n] is lower than [1]
+      the function will returns [None]. *)
 
   val reduce_nel : 'a t Preface_core.Nonempty_list.t -> 'a t
   (** Reduce a [Nonempty_list.t] using [combine]. *)

--- a/lib/preface_specs/alternative.mli
+++ b/lib/preface_specs/alternative.mli
@@ -62,6 +62,10 @@ module type ALTERNATIVE_OPERATION = sig
   include Alt.OPERATION
   (** @inline *)
 
+  val times : int -> 'a t -> 'a t
+  (** [times n x] apply [combine] on [x] [n] times. If [n] is lower than [1] the
+      function will returns [neutral]. *)
+
   val reduce : 'a t list -> 'a t
   (** Reduce a [List.t] using [combine]. *)
 end

--- a/lib/preface_specs/arrow_alt.mli
+++ b/lib/preface_specs/arrow_alt.mli
@@ -55,7 +55,7 @@ module type OPERATION = sig
   include Arrow.OPERATION
   (** @inline *)
 
-  val times : int -> ('a, 'b) t -> ('a, 'b) t option
+  val times_nel : int -> ('a, 'b) t -> ('a, 'b) t option
   (** [times n x] apply [combine] on [x] [n] times. If [n] is lower than [1] the
       function will returns [None]. *)
 

--- a/lib/preface_specs/arrow_plus.mli
+++ b/lib/preface_specs/arrow_plus.mli
@@ -56,6 +56,10 @@ module type OPERATION = sig
   include Arrow_alt.OPERATION
   (** @inline *)
 
+  val times : int -> ('a, 'b) t -> ('a, 'b) t
+  (** [times_nel n x] apply [combine] on [x] [n] times. If [n] is lower than [1]
+      the function will returns [neutral]. *)
+
   val reduce : ('a, 'b) t list -> ('a, 'b) t
   (** Reduce a [List.t] using [combine]. *)
 end

--- a/lib/preface_specs/foldable.mli
+++ b/lib/preface_specs/foldable.mli
@@ -1,5 +1,5 @@
-(** A [Foldable] is a data structure which can be fold. In other word, reduced to
-    a summary value one element at a time *)
+(** A [Foldable] is a data structure which can be fold. In other word, reduced
+    to a summary value one element at a time *)
 
 (** {1 Minimal definition} *)
 

--- a/lib/preface_specs/monoid.mli
+++ b/lib/preface_specs/monoid.mli
@@ -44,6 +44,10 @@ module type OPERATION = sig
   include Semigroup.OPERATION
   (** @inline *)
 
+  val times : int -> t -> t
+  (** [times n x] apply [combine] on [x] [n] times. If [n] is lower than [1] the
+      function will returns [neutral]. *)
+
   val reduce : t list -> t
   (** Reduce a [List.t] using [combine]. *)
 end

--- a/lib/preface_specs/semigroup.mli
+++ b/lib/preface_specs/semigroup.mli
@@ -30,9 +30,9 @@ module type OPERATION = sig
   type t
   (** the type held by the [Semigroup]. *)
 
-  val times : int -> t -> t option
-  (** [times n x] apply [combine] on [x] [n] times. If [n] is lower than [1] the
-      function will returns [None]. *)
+  val times_nel : int -> t -> t option
+  (** [times_nel n x] apply [combine] on [x] [n] times. If [n] is lower than [1]
+      the function will returns [None]. *)
 
   val reduce_nel : t Preface_core.Nonempty_list.t -> t
   (** Reduce a [Nonempty_list.t] using [combine]. *)

--- a/lib/preface_stdlib/stream.mli
+++ b/lib/preface_stdlib/stream.mli
@@ -45,8 +45,8 @@ val cons : 'a -> 'a t -> 'a t
 (** Alias of {!val:stream}. *)
 
 val hd : 'a t -> 'a
-(** Get the head of the stream. Since [Stream.t] are infinite, [hd] can not
-    fail (without values). For each stream, we have an head. *)
+(** Get the head of the stream. Since [Stream.t] are infinite, [hd] can not fail
+    (without values). For each stream, we have an head. *)
 
 val tl : 'a t -> 'a t
 (** Get the tail of the stream. Like [hd], since [Stream.t] are infinite, the


### PR DESCRIPTION
In all monoïdal form we can provide the neutral element instead of an
Option. (The choice of option was good for Semigroup since Option is one
of the free monoid over a Semigroup).