### PR TITLE
Add `('a, 'b) handle` to simplify handlers

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,28 +1,20 @@
-version = 0.19.0
+version = 0.20.1
 margin = 80
 max-indent = 68
 
-align-cases = false
-align-constructors-decl = false
-align-variants-decl = false
 assignment-operator = begin-line
 
-break-before-in = fit-or-vertical
 break-cases = fit
-break-collection-expressions = fit-or-vertical
 break-fun-decl = wrap
 break-fun-sig = fit-or-vertical
 break-infix = fit-or-vertical
 break-infix-before-func = true
 break-separators = before
 break-sequences = true
-break-string-literals = auto
-break-struct = force
 
 cases-exp-indent = 2
 cases-matching-exp-indent = normal
 
-disambiguate-non-breaking-match = true
 
 doc-comments = after-when-possible
 doc-comments-padding = 2
@@ -31,16 +23,9 @@ dock-collection-brackets = true
 
 exp-grouping = preserve
 
-extension-indent = 2
-
 field-space = loose
 
-function-indent = 2
-function-indent-nested = never
-
 if-then-else = keyword-first
-
-indent-after-in = 0
 
 indicate-multiline-delimiters = space
 indicate-nested-or-patterns = unsafe-no
@@ -50,17 +35,10 @@ infix-precedence = indent
 leading-nested-match-parens = false
 
 let-and = sparse
-let-binding-indent = 2
 let-binding-spacing = double-semicolon
 let-module = compact
 
-match-indent = 0
-match-indent-nested = never
-module-item-spacing = sparse
-nested-match = wrap
-
 parens-tuple = always
-parens-tuple-patterns = always
 
 parse-docstrings = true
 
@@ -73,10 +51,7 @@ space-around-lists = true
 space-around-records = true
 space-around-variants = true
 
-stritem-extension-indent = 0
-
 type-decl = sparse
-type-decl-indent = 2
 
 wrap-comments = false
 wrap-fun-args = true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## dev (Unreleased)
  
+- Add `('a, 'b) handle` to simplify handlers for `Freer_monad` [**@xvw**](https://github.com/xvw)
 - Rename `times` to `times_to_nel` for _semigroup-ish_ and add `times` for _monoid-ish_ [**@xvw**](https://github.com/xvw)
 - Add `Decidable` (Contravariant analogue for `Alternative`) and add some missing infixes operators for `Divisible` [**@gr-im**](https://github.com/gr-im)
 - Removing early destructive substitution [**@xhtmlboi**](https://github.com/xhtmlboi)

--- a/guides/freer_effect_handling.md
+++ b/guides/freer_effect_handling.md
@@ -188,7 +188,7 @@ effects, propagated by our program, for example:
 
 ```ocaml
 let run program =
-  let handler : type b. (b -> 'a) -> b IO.f -> 'a =
+  let handler : type a. (a, 'b) IO.handle =
     fun resume -> function
       | Print message ->
         let () = print_endline message in

--- a/lib/preface_core/fun.ml
+++ b/lib/preface_core/fun.ml
@@ -1,18 +1,12 @@
 let compose_left_to_right f g x = g (f x)
-
 let compose_right_to_left f g x = f (g x)
-
 let const x _ = x
-
 let id x = x
-
 let flip f x y = f y x
 
 module Infix = struct
   let ( %> ) = compose_left_to_right
-
   let ( <% ) = compose_right_to_left
-
   let ( % ) = compose_right_to_left
 end
 

--- a/lib/preface_core/monoid.ml
+++ b/lib/preface_core/monoid.ml
@@ -11,5 +11,4 @@ let times combine neutral n x =
 ;;
 
 let reduce_nel combine list = Nonempty_list.reduce combine list
-
 let reduce combine neutral list = List.fold_left combine neutral list

--- a/lib/preface_core/nonempty_list.ml
+++ b/lib/preface_core/nonempty_list.ml
@@ -5,11 +5,10 @@ type 'a t =
 let create x = Last x
 
 let rec rev_append l1 l2 =
-  (match l1 with Last x -> x :: l2 | x :: xs -> rev_append xs (x :: l2))
+  match l1 with Last x -> x :: l2 | x :: xs -> rev_append xs (x :: l2)
 ;;
 
 let hd = function Last x | x :: _ -> x
-
 let tl = function Last _ -> None | _ :: xs -> Some xs
 
 let rev = function
@@ -124,8 +123,8 @@ let flatten = function
 
 let equal f a b =
   let rec eq_aux = function
-    | (Last x, Last y) -> f x y
-    | (x :: xs, y :: ys) -> f x y && eq_aux (xs, ys)
+    | Last x, Last y -> f x y
+    | x :: xs, y :: ys -> f x y && eq_aux (xs, ys)
     | _ -> false
   in
   eq_aux (a, b)

--- a/lib/preface_core/shims.ml
+++ b/lib/preface_core/shims.ml
@@ -2,6 +2,5 @@ module Either = struct
   include Either
 
   let case f g = function Either.Left x -> f x | Either.Right x -> g x
-
   let swap x = Either.fold ~left:Either.right ~right:Either.left x
 end

--- a/lib/preface_core/void.ml
+++ b/lib/preface_core/void.ml
@@ -1,7 +1,5 @@
 type t = |
 
 let absurd : t -> 'a = function _ -> .
-
 let left x = Either.fold ~left:Fun.id ~right:absurd x
-
 let right x = Either.fold ~left:absurd ~right:Fun.id x

--- a/lib/preface_core/void.mli
+++ b/lib/preface_core/void.mli
@@ -9,7 +9,7 @@ val absurd : t -> 'a
     their negations) can be inferred from it; this is known as deductive
     explosion.*)
 
-(** {As an identity for Either}
+(** {1 As an identity for Either}
 
     [Void.t] act as an identity for [Either]. *)
 

--- a/lib/preface_make/alt.ml
+++ b/lib/preface_make/alt.ml
@@ -10,7 +10,6 @@ module Core (Req : Preface_specs.Alt.WITH_COMBINE_AND_MAP) = Req
 
 module Times_and_reduce_nel (Core : Preface_specs.Alt.WITH_COMBINE) = struct
   let times_nel n x = Preface_core.Monoid.times_nel Core.combine n x
-
   let reduce_nel list = Preface_core.Monoid.reduce_nel Core.combine list
 end
 

--- a/lib/preface_make/alternative.ml
+++ b/lib/preface_make/alternative.ml
@@ -4,7 +4,6 @@ struct
   include Applicative.Core_via_map_and_product (Req)
 
   let combine = Req.combine
-
   let neutral = Req.neutral
 end
 
@@ -12,7 +11,6 @@ module Core_via_apply (Req : Preface_specs.Alternative.WITH_APPLY) = struct
   include Applicative.Core_via_apply (Req)
 
   let combine = Req.combine
-
   let neutral = Req.neutral
 end
 
@@ -20,7 +18,6 @@ module Core_via_lift2 (Req : Preface_specs.Alternative.WITH_LIFT2) = struct
   include Applicative.Core_via_lift2 (Req)
 
   let combine = Req.combine
-
   let neutral = Req.neutral
 end
 
@@ -31,7 +28,6 @@ module Operation (Core : Preface_specs.Alternative.CORE) = struct
   include Alt.Operation (Core)
 
   let times n x = Preface_core.Monoid.times Core.combine Core.neutral n x
-
   let reduce list = reduce' Core.combine Core.neutral list
 end
 
@@ -103,7 +99,6 @@ module Over_applicative
       include Applicative
 
       let combine = Req.combine
-
       let neutral = Req.neutral
     end)
     (struct
@@ -115,7 +110,6 @@ module Over_applicative
       include Applicative
 
       let times n x = Preface_core.Monoid.times Req.combine Req.neutral n x
-
       let reduce list = reduce' Req.combine Req.neutral list
     end)
     (struct
@@ -134,7 +128,6 @@ module Composition
          type 'a t = 'a G.t F.t
 
          let neutral = F.neutral
-
          let combine = F.combine
        end)
 
@@ -146,7 +139,6 @@ module From_arrow_plus (A : Preface_specs.ARROW_PLUS) =
          type 'a t = (unit, 'a) A.t
 
          let neutral = A.neutral
-
          let combine x y = A.(x <|> y)
        end)
 
@@ -157,6 +149,5 @@ module Product (F : Preface_specs.ALTERNATIVE) (G : Preface_specs.ALTERNATIVE) =
          type 'a t = 'a F.t * 'a G.t
 
          let neutral = (F.neutral, G.neutral)
-
          let combine (x1, y1) (x2, y2) = (F.combine x1 x2, G.combine y1 y2)
        end)

--- a/lib/preface_make/applicative.ml
+++ b/lib/preface_make/applicative.ml
@@ -6,7 +6,6 @@ struct
   include Req
 
   let apply f a = map (fun (f, a) -> f a) @@ product f a
-
   let lift2 f x y = apply (map f x) y
 end
 
@@ -14,9 +13,7 @@ module Core_via_apply (Req : Preface_specs.Applicative.WITH_APPLY) = struct
   include Req
 
   let map f a = apply (pure f) a
-
   let product a b = apply (apply (pure (fun a b -> (a, b))) a) b
-
   let lift2 f x y = apply (map f x) y
 end
 
@@ -24,9 +21,7 @@ module Core_via_lift2 (Req : Preface_specs.Applicative.WITH_LIFT2) = struct
   include Req
 
   let apply f a = lift2 (fun x -> x) f a
-
   let map f a = apply (pure f) a
-
   let product a b = apply (apply (pure (fun a b -> (a, b))) a) b
 end
 
@@ -34,7 +29,6 @@ module Operation (Core : Preface_specs.Applicative.CORE) = struct
   include Functor.Operation (Core)
 
   let lift = Core.map
-
   let lift3 f a b = Core.(apply @@ apply (apply (pure f) a) b)
 end
 
@@ -42,7 +36,6 @@ module Syntax (Core : Preface_specs.Applicative.CORE) = struct
   type 'a t = 'a Core.t
 
   let ( let+ ) x f = Core.map f x
-
   let ( and+ ) = Core.product
 end
 
@@ -53,11 +46,8 @@ struct
   include Functor.Infix (Core) (Operation)
 
   let ( <*> ) = Core.apply
-
   let ( <**> ) a b = Core.lift2 (fun x f -> f x) a b
-
   let ( *> ) a b = Core.lift2 (fun _x y -> y) a b
-
   let ( <* ) a b = Core.lift2 const a b
 end
 
@@ -134,7 +124,6 @@ Via_apply (struct
   type 'a t = 'a G.t F.t
 
   let pure x = F.pure (G.pure x)
-
   let apply f x = F.lift2 G.apply f x
 end)
 
@@ -142,9 +131,7 @@ module From_arrow (A : Preface_specs.ARROW) = Via_apply (struct
   type 'a t = (unit, 'a) A.t
 
   let pure x = A.arrow (const x)
-
   let uncurry f (x, y) = f x y
-
   let apply f x = A.(f &&& x >>> arrow (uncurry Fun.id))
 end)
 
@@ -153,7 +140,6 @@ Via_apply (struct
   type 'a t = 'a F.t * 'a G.t
 
   let pure x = (F.pure x, G.pure x)
-
   let apply (f, g) (x, y) = (F.apply f x, G.apply g y)
 end)
 
@@ -165,7 +151,6 @@ module Const (M : Preface_specs.Monoid.CORE) = struct
       type nonrec 'a t = 'a t
 
       let pure _ = Const M.neutral
-
       let apply (Const f) (Const x) = Const (M.combine f x)
     end) :
       Preface_specs.APPLICATIVE with type 'a t := 'a t )

--- a/lib/preface_make/arrow.ml
+++ b/lib/preface_make/arrow.ml
@@ -31,7 +31,6 @@ struct
   include Category
 
   let return () = Core.arrow (fun x -> x)
-
   let snd x = Core.split Core.id x
 
   let fan_out pre post =
@@ -39,11 +38,8 @@ struct
   ;;
 
   let pre_compose_left_to_right f x = compose_left_to_right (Core.arrow f) x
-
   let post_compose_left_to_right x f = compose_left_to_right x (Core.arrow f)
-
   let pre_compose_right_to_left x f = compose_right_to_left x (Core.arrow f)
-
   let post_compose_right_to_left f x = compose_right_to_left (Core.arrow f) x
 end
 
@@ -51,7 +47,6 @@ module Alias (Operation : Preface_specs.Arrow.OPERATION) = struct
   type ('a, 'b) t = ('a, 'b) Operation.t
 
   let pre_compose f x = Operation.pre_compose_left_to_right f x
-
   let post_compose x f = Operation.post_compose_left_to_right x f
 end
 
@@ -63,15 +58,10 @@ struct
   include Category
 
   let ( *** ) l r = Core.split l r
-
   let ( &&& ) l r = Operation.fan_out l r
-
   let ( ^>> ) l r = Operation.pre_compose_left_to_right l r
-
   let ( >>^ ) l r = Operation.post_compose_left_to_right l r
-
   let ( <<^ ) l r = Operation.pre_compose_right_to_left l r
-
   let ( ^<< ) l r = Operation.post_compose_right_to_left l r
 end
 
@@ -125,7 +115,6 @@ module From_monad (Monad : Preface_specs.Monad.CORE) = struct
     type ('a, 'b) t = 'a -> 'b Monad.t
 
     let arrow f = (fun f g x -> f (g x)) Monad.return f
-
     let fst f (b, d) = Monad.bind (fun c -> Monad.return (c, d)) (f b)
   end
 
@@ -147,7 +136,6 @@ module From_strong_and_category
       type ('a, 'b) t = ('a, 'b) Category.t
 
       let arrow f = Strong.dimap f (fun x -> x) Category.id
-
       let fst = Strong.fst
     end)
 
@@ -158,6 +146,5 @@ module Product (F : Preface_specs.ARROW) (G : Preface_specs.ARROW) =
          type ('a, 'b) t = ('a, 'b) F.t * ('a, 'b) G.t
 
          let arrow f = (F.arrow f, G.arrow f)
-
          let fst (x, y) = (F.fst x, G.fst y)
        end)

--- a/lib/preface_make/arrow_alt.ml
+++ b/lib/preface_make/arrow_alt.ml
@@ -26,7 +26,6 @@ struct
   include Arrow.Operation_over_category (Category) (Core)
 
   let times_nel n x = Preface_core.Monoid.times_nel Core.combine n x
-
   let reduce_nel list = Preface_core.Monoid.reduce_nel Core.combine list
 end
 

--- a/lib/preface_make/arrow_choice.ml
+++ b/lib/preface_make/arrow_choice.ml
@@ -83,7 +83,6 @@ struct
   include Arrow.Operation_over_category (Category) (Core)
 
   let right x = Core.choose Core.id x
-
   let fan_in f g = Core.compose (Core.arrow extract) (Core.choose f g)
 end
 
@@ -99,7 +98,6 @@ struct
   include Arrow.Infix_over_category (Category) (Core) (Operation)
 
   let ( +++ ) = Core.choose
-
   let ( ||| ) = Operation.fan_in
 end
 
@@ -123,6 +121,7 @@ module Over_category_and_via_arrow_and_fst_and_left
 struct
   module Core =
     Core_over_category_and_via_arrow_and_fst_and_left (Category) (Req)
+
   module Operation = Operation_over_category (Category) (Core)
   module Alias = Alias (Operation)
   module Infix = Infix_over_category (Category.Infix) (Core) (Operation)
@@ -139,6 +138,7 @@ module Over_over_category_and_via_arrow_and_split_and_left
 struct
   module Core =
     Core_over_category_and_via_arrow_and_split_and_left (Category) (Req)
+
   module Operation = Operation_over_category (Category) (Core)
   module Alias = Alias (Operation)
   module Infix = Infix_over_category (Category.Infix) (Core) (Operation)
@@ -155,6 +155,7 @@ module Over_category_and_via_arrow_and_fst_and_choose
 struct
   module Core =
     Core_over_category_and_via_arrow_and_fst_and_choose (Category) (Req)
+
   module Operation = Operation_over_category (Category) (Core)
   module Alias = Alias (Operation)
   module Infix = Infix_over_category (Category.Infix) (Core) (Operation)
@@ -171,6 +172,7 @@ module Over_category_and_via_arrow_and_split_and_choose
 struct
   module Core =
     Core_over_category_and_via_arrow_and_split_and_choose (Category) (Req)
+
   module Operation = Operation_over_category (Category) (Core)
   module Alias = Alias (Operation)
   module Infix = Infix_over_category (Category) (Core) (Operation)

--- a/lib/preface_make/arrow_plus.ml
+++ b/lib/preface_make/arrow_plus.ml
@@ -6,7 +6,6 @@ struct
   include Arrow.Core_over_category_and_via_arrow_and_fst (Category) (Req)
 
   let combine = Req.combine
-
   let neutral = Req.neutral
 end
 
@@ -18,7 +17,6 @@ struct
   include Arrow.Core_over_category_and_via_arrow_and_split (Category) (Req)
 
   let combine = Req.combine
-
   let neutral = Req.neutral
 end
 
@@ -30,11 +28,8 @@ struct
   include Arrow.Operation_over_category (Category) (Core)
 
   let times_nel n x = Preface_core.Monoid.times_nel Core.combine n x
-
   let reduce_nel list = Preface_core.Monoid.reduce_nel Core.combine list
-
   let times n x = Preface_core.Monoid.times Core.combine Core.neutral n x
-
   let reduce list = Preface_core.Monoid.reduce Core.combine Core.neutral list
 end
 
@@ -130,7 +125,6 @@ module From_monad_plus (Monad : Preface_specs.Monad_plus.CORE) =
          type ('a, 'b) t = 'a -> 'b Monad.t
 
          let combine f g x = Monad.combine (f x) (g x)
-
          let neutral _ = Monad.neutral
        end)
 
@@ -141,6 +135,5 @@ module Product (F : Preface_specs.ARROW_PLUS) (G : Preface_specs.ARROW_PLUS) =
          type ('a, 'b) t = ('a, 'b) F.t * ('a, 'b) G.t
 
          let neutral = (F.neutral, G.neutral)
-
          let combine (x1, y1) (x2, y2) = (F.combine x1 x2, G.combine y1 y2)
        end)

--- a/lib/preface_make/arrow_zero.ml
+++ b/lib/preface_make/arrow_zero.ml
@@ -79,8 +79,10 @@ struct
       end)
 
   module Operation_aux = Operation_over_category (Arrow) (Core_aux)
+
   module Infix_aux =
     Infix_over_category (Arrow.Infix) (Core_aux) (Operation_aux)
+
   include Core_aux
   include Operation_aux
   include Arrow

--- a/lib/preface_make/bifunctor.ml
+++ b/lib/preface_make/bifunctor.ml
@@ -4,7 +4,6 @@ module Core_via_bimap (Req : Preface_specs.Bifunctor.WITH_BIMAP) = struct
   include Req
 
   let map_fst f = bimap f id
-
   let map_snd f = bimap id f
 end
 
@@ -20,7 +19,6 @@ module Operation (Core : Preface_specs.Bifunctor.CORE) = struct
   type ('a, 'b) t = ('a, 'b) Core.t
 
   let replace_fst value x = Core.map_fst (const value) x
-
   let replace_snd value x = Core.map_snd (const value) x
 end
 
@@ -56,7 +54,6 @@ Via_map_fst_and_map_snd (struct
   type ('a, 'b) t = 'a F.t * 'b G.t
 
   let map_fst f (x, y) = (F.map f x, y)
-
   let map_snd f (x, y) = (x, G.map f y)
 end)
 

--- a/lib/preface_make/category.ml
+++ b/lib/preface_make/category.ml
@@ -33,7 +33,6 @@ Via_id_and_compose (struct
   type ('a, 'b) t = 'a -> 'b Monad.t
 
   let id = Monad.return
-
   let compose f g = Monad.compose_left_to_right g f
 end)
 
@@ -44,7 +43,6 @@ Via_id_and_compose (struct
   type ('a, 'b) t = ('a, 'b) G.t
 
   let id = Req.id
-
   let compose = G.compose
 end)
 
@@ -53,6 +51,5 @@ Via_id_and_compose (struct
   type ('a, 'b) t = ('a, 'b) F.t * ('a, 'b) G.t
 
   let id = (F.id, G.id)
-
   let compose (x1, y1) (x2, y2) = (F.compose x1 x2, G.compose y1 y2)
 end)

--- a/lib/preface_make/cokleisli.ml
+++ b/lib/preface_make/cokleisli.ml
@@ -19,7 +19,6 @@ Strong.Via_dimap_and_fst (struct
   type ('a, 'b) t = 'a C.t -> 'b
 
   let dimap f g p = C.map f %> p %> g
-
   let fst f x = (f (C.map Stdlib.fst x), Stdlib.snd (C.extract x))
 end)
 
@@ -38,7 +37,6 @@ Category.Via_id_and_compose (struct
   type ('a, 'b) t = 'a C.t -> 'b
 
   let id = C.extract
-
   let compose f g = C.compose_left_to_right g f
 end)
 

--- a/lib/preface_make/comonad.ml
+++ b/lib/preface_make/comonad.ml
@@ -7,7 +7,6 @@ struct
   include Req
 
   let extend f = duplicate %> map f
-
   let compose_left_to_right f g = duplicate %> map f %> g
 end
 
@@ -15,9 +14,7 @@ module Core_via_extend (Req : Preface_specs.Comonad.WITH_EXTEND) = struct
   include Req
 
   let duplicate a = extend id a
-
   let compose_left_to_right f g = extend f %> g
-
   let map f = extend @@ (extract %> f)
 end
 
@@ -27,9 +24,7 @@ struct
   include Req
 
   let extend f = compose_left_to_right f id
-
   let duplicate a = compose_left_to_right id id a
-
   let map f = compose_left_to_right (extract %> f) id
 end
 
@@ -37,7 +32,6 @@ module Syntax (Core : Preface_specs.Comonad.CORE) = struct
   type 'a t = 'a Core.t
 
   let ( let@ ) e f = Core.extend f e
-
   let ( let+ ) e f = Core.map f e
 end
 
@@ -45,11 +39,8 @@ module Operation (Core : Preface_specs.Comonad.CORE) = struct
   include Functor.Operation (Core)
 
   let lift = Core.map
-
   let lift2 f a = Core.(map @@ extract @@ lift f a)
-
   let lift3 f a b = Core.(map @@ extract @@ lift2 f a b)
-
   let compose_right_to_left f g = Core.compose_left_to_right g f
 end
 
@@ -60,19 +51,12 @@ struct
   include Functor.Infix (Core) (Operation)
 
   let ( <<= ) = Core.extend
-
   let ( =>> ) a f = Core.extend f a
-
   let ( =>= ) = Core.compose_left_to_right
-
   let ( =<= ) = Operation.compose_right_to_left
-
   let ( <@> ) f a = Core.(map (extract f) a)
-
   let ( <@@> ) a f = f <@> a
-
   let ( <@ ) a = Core.(map @@ extract @@ map const a)
-
   let ( @> ) a b = b <@ a
 end
 

--- a/lib/preface_make/contravariant.ml
+++ b/lib/preface_make/contravariant.ml
@@ -15,11 +15,8 @@ struct
   type 'a t = 'a Core.t
 
   let ( >$ ) x c = Operation.replace x c
-
   let ( $< ) c x = Operation.replace x c
-
   let ( >$< ) f c = Core.contramap f c
-
   let ( >&< ) c f = Core.contramap f c
 end
 

--- a/lib/preface_make/decidable.ml
+++ b/lib/preface_make/decidable.ml
@@ -21,7 +21,6 @@ module Operation (Core : Preface_specs.Decidable.CORE) = struct
   include Divisible.Operation (Core)
 
   let lost = Core.lose Fun.id
-
   let chosen a b = Core.choose Fun.id a b
 end
 

--- a/lib/preface_make/divisible.ml
+++ b/lib/preface_make/divisible.ml
@@ -16,7 +16,6 @@ module Operation (Core : Preface_specs.Divisible.CORE) = struct
   include Contravariant.Operation (Core)
 
   let divided x = Core.divide id x
-
   let conquered = Core.conquer
 end
 
@@ -27,9 +26,7 @@ struct
   include Contravariant.Infix (Core) (Operation)
 
   let ( >*< ) = Operation.divided
-
   let ( >* ) x = Core.divide (fun x -> (x, ())) x
-
   let ( *< ) x y = Core.divide (fun x -> ((), x)) x y
 end
 

--- a/lib/preface_make/env.ml
+++ b/lib/preface_make/env.ml
@@ -3,7 +3,6 @@ module Core_over_comonad
     (Env : Preface_specs.Types.T0) =
 struct
   type env = Env.t
-
   type 'a comonad = 'a C.t
 
   let lower (_, c) = c
@@ -11,11 +10,8 @@ struct
   type 'a t = env * 'a comonad
 
   let run (e, c) = (e, c)
-
   let ask (e, _) = e
-
   let asks f (e, _) = f e
-
   let local f (e, c) = (f e, c)
 
   module Local (Env : Preface_specs.Types.T0) = struct
@@ -37,7 +33,6 @@ Comonad.Via_map_and_duplicate (struct
   include Functor (C) (Env)
 
   let duplicate (e, c) = (e, C.extend (fun x -> (e, x)) c)
-
   let extract (_, c) = C.extract c
 end)
 
@@ -46,7 +41,6 @@ Applicative.Via_apply (struct
   type 'a t = Env.t * 'a A.t
 
   let pure x = (Env.neutral, A.pure x)
-
   let apply (m, a) (n, b) = (Env.combine m n, A.apply a b)
 end)
 

--- a/lib/preface_make/foldable.ml
+++ b/lib/preface_make/foldable.ml
@@ -35,9 +35,7 @@ module Operation (C : Preface_specs.Foldable.CORE) = struct
   ;;
 
   let for_all p x = C.fold_map' true ( && ) p x
-
   let exists p x = C.fold_map' false ( || ) p x
-
   let length x = fold_left (fun acc _ -> succ acc) 0 x
 end
 
@@ -46,7 +44,6 @@ module Via
     (O : Preface_specs.Foldable.OPERATION with type 'a t = 'a C.t) =
 struct
   include C
-
   include (O : Preface_specs.Foldable.OPERATION with type 'a t := 'a t)
 end
 

--- a/lib/preface_make/free_applicative.ml
+++ b/lib/preface_make/free_applicative.ml
@@ -37,14 +37,13 @@ struct
    ;;
 
     let product a b = apply (apply (Pure (fun x y -> (x, y))) a) b
-
     let lift2 f x y = apply (map f x) y
   end
 
   module Operation = Applicative.Operation (Core)
+
   module A =
-    Applicative.Via (Core) (Operation)
-      (Applicative.Infix (Core) (Operation))
+    Applicative.Via (Core) (Operation) (Applicative.Infix (Core) (Operation))
       (Applicative.Syntax (Core))
 
   module To_applicative (Applicative : Preface_specs.Applicative.CORE) = struct

--- a/lib/preface_make/free_selective.ml
+++ b/lib/preface_make/free_selective.ml
@@ -23,7 +23,6 @@ module Over_functor (F : Preface_specs.Functor.CORE) = struct
     type nonrec 'a t = 'a t
 
     let bimap f g = Either.case (Either.left % f) (Either.right % g)
-
     let pure x = Pure x
 
     let rec select : type a b. (a, b) Either.t t -> (a -> b) t -> b t =

--- a/lib/preface_make/freer_monad.ml
+++ b/lib/preface_make/freer_monad.ml
@@ -7,10 +7,10 @@ module Over (Type : Preface_specs.Types.T1) = struct
     | Return : 'a -> 'a t
     | Bind : 'b f * ('b -> 'a t) -> 'a t
 
-  let perform f = Bind (f, (fun a -> Return a))
+  let perform f = Bind (f, fun a -> Return a)
 
   type ('a, 'b) handle = ('a -> 'b) -> 'a f -> 'b
-  type 'a handler = { handler : 'b. ('b, 'a) handle}
+  type 'a handler = { handler : 'b. ('b, 'a) handle }
 
   let run f =
     let rec loop_run = function
@@ -41,7 +41,7 @@ module Over (Type : Preface_specs.Types.T1) = struct
     let rec apply f a =
       match f with
       | Return f' -> map f' a
-      | Bind (i, c) -> Bind (i, c %> (fun f -> apply f a))
+      | Bind (i, c) -> Bind (i, c %> fun f -> apply f a)
     ;;
   end)
 

--- a/lib/preface_make/freer_monad.ml
+++ b/lib/preface_make/freer_monad.ml
@@ -9,7 +9,8 @@ module Over (Type : Preface_specs.Types.T1) = struct
 
   let perform f = Bind (f, (fun a -> Return a))
 
-  type 'a handler = { handler : 'b. ('b -> 'a) -> 'b f -> 'a }
+  type ('a, 'b) handle = ('a -> 'b) -> 'a f -> 'b
+  type 'a handler = { handler : 'b. ('b, 'a) handle}
 
   let run f =
     let rec loop_run = function

--- a/lib/preface_make/functor.ml
+++ b/lib/preface_make/functor.ml
@@ -5,7 +5,6 @@ module Operation (Core : Preface_specs.Functor.CORE) = struct
   type 'a t = 'a Core.t
 
   let replace value x = (Core.map <% const) value x
-
   let void x = replace () x
 end
 
@@ -16,11 +15,8 @@ struct
   type 'a t = 'a Operation.t
 
   let ( <$> ) = Core.map
-
   let ( <&> ) x f = Core.map f x
-
   let ( <$ ) value x = Operation.replace value x
-
   let ( $> ) x value = Operation.replace value x
 end
 

--- a/lib/preface_make/monad.ml
+++ b/lib/preface_make/monad.ml
@@ -4,9 +4,7 @@ module Core_via_bind (Req : Preface_specs.Monad.WITH_BIND) = struct
   include Req
 
   let join m = bind id m
-
   let map f m = bind (return <% f) m
-
   let compose_left_to_right f g x = bind g (f x)
 end
 
@@ -15,7 +13,6 @@ struct
   include Req
 
   let bind f m = join (map f m)
-
   let compose_left_to_right f g x = bind g (f x)
 end
 
@@ -25,9 +22,7 @@ struct
   include Req
 
   let bind f m = (compose_left_to_right (const m) f) ()
-
   let join m = bind id m
-
   let map f m = bind (return <% f) m
 end
 
@@ -35,9 +30,7 @@ module Operation (Core : Preface_specs.Monad.CORE) = struct
   include Functor.Operation (Core)
 
   let void _ = Core.return ()
-
   let compose_right_to_left f g x = Core.compose_left_to_right g f x
-
   let lift = Core.map
 
   let lift2 f ma mb =
@@ -54,7 +47,6 @@ module Syntax (Core : Preface_specs.Monad.CORE) = struct
   type 'a t = 'a Core.t
 
   let ( let* ) m f = Core.bind f m
-
   let ( let+ ) m f = Core.map f m
 end
 
@@ -65,19 +57,12 @@ struct
   include Functor.Infix (Core) (Operation)
 
   let ( >|= ) x f = Core.map f x
-
   let ( =|< ) = Core.map
-
   let ( >>= ) x f = Core.bind f x
-
   let ( =<< ) = Core.bind
-
   let ( >=> ) = Core.compose_left_to_right
-
   let ( <=< ) = Operation.compose_right_to_left
-
-  let ( >> ) ma mb = ma >>= (fun _ -> mb)
-
+  let ( >> ) ma mb = ma >>= fun _ -> mb
   let ( << ) ma _ = ma
 end
 
@@ -136,7 +121,6 @@ module From_arrow_apply (A : Preface_specs.ARROW_APPLY) = Via_bind (struct
   type 'a t = (unit, 'a) A.t
 
   let return x = A.arrow (const x)
-
   let bind f x = A.(x >>> arrow (fun x -> (f x, ())) >>> apply)
 end)
 
@@ -145,6 +129,5 @@ Via_bind (struct
   type 'a t = 'a F.t * 'a G.t
 
   let return x = (F.return x, G.return x)
-
   let bind f (m, n) = (F.bind (fst % f) m, G.bind (snd % f) n)
 end)

--- a/lib/preface_make/monad_plus.ml
+++ b/lib/preface_make/monad_plus.ml
@@ -2,7 +2,6 @@ module Core_via_bind (Req : Preface_specs.Monad_plus.WITH_BIND) = struct
   include Monad.Core_via_bind (Req)
 
   let combine = Req.combine
-
   let neutral = Req.neutral
 end
 
@@ -11,7 +10,6 @@ struct
   include Monad.Core_via_map_and_join (Req)
 
   let combine = Req.combine
-
   let neutral = Req.neutral
 end
 
@@ -21,7 +19,6 @@ struct
   include Monad.Core_via_kleisli_composition (Req)
 
   let combine = Req.combine
-
   let neutral = Req.neutral
 end
 
@@ -34,7 +31,6 @@ module Operation (Core : Preface_specs.Monad_plus.CORE) = struct
   include Alt.Operation (Core)
 
   let times n x = Preface_core.Monoid.times Core.combine Core.neutral n x
-
   let reduce list = Preface_core.Monoid.reduce Core.combine Core.neutral list
 
   let filter predicate m =
@@ -55,7 +51,6 @@ struct
   end)
 
   let times n x = Preface_core.Monoid.times Req.combine Req.neutral n x
-
   let reduce list = Preface_core.Monoid.reduce Req.combine Req.neutral list
 
   let filter predicate m =
@@ -133,7 +128,6 @@ module Over_monad
       include Monad
 
       let combine = Req.combine
-
       let neutral = Req.neutral
     end)
     (Operation_over_monad (Monad) (Req))
@@ -148,6 +142,7 @@ module Over_monad_and_alternative
     (Monad : Preface_specs.MONAD)
     (Alternative : Preface_specs.ALTERNATIVE with type 'a t = 'a Monad.t) =
   Over_monad (Monad) (Alternative)
+
 module From_arrow_apply_and_arrow_plus
     (A : Preface_specs.ARROW_APPLY)
     (P : Preface_specs.ARROW_PLUS with type ('a, 'b) t = ('a, 'b) A.t) =
@@ -161,6 +156,5 @@ module Product (F : Preface_specs.MONAD_PLUS) (G : Preface_specs.MONAD_PLUS) =
          type 'a t = 'a F.t * 'a G.t
 
          let neutral = (F.neutral, G.neutral)
-
          let combine (x1, y1) (x2, y2) = (F.combine x1 x2, G.combine y1 y2)
        end)

--- a/lib/preface_make/monoid.ml
+++ b/lib/preface_make/monoid.ml
@@ -13,7 +13,6 @@ module Operation (Core : Preface_specs.Monoid.CORE) = struct
   include Semigroup.Operation (Core)
 
   let times n x = Preface_core.Monoid.times Core.combine Core.neutral n x
-
   let reduce list = Preface_core.Monoid.reduce Core.combine Core.neutral list
 end
 
@@ -62,7 +61,6 @@ Via_combine_and_neutral (struct
   type t = T.t Alternative.t
 
   let combine = Alternative.combine
-
   let neutral = Alternative.neutral
 end)
 
@@ -73,6 +71,5 @@ Via_combine_and_neutral (struct
   type t = T.t Monad_plus.t
 
   let combine = Monad_plus.combine
-
   let neutral = Monad_plus.neutral
 end)

--- a/lib/preface_make/profunctor.ml
+++ b/lib/preface_make/profunctor.ml
@@ -2,7 +2,6 @@ module Core_via_dimap (Req : Preface_specs.Profunctor.WITH_DIMAP) = struct
   include Req
 
   let contramap_fst f x = Req.dimap f Fun.id x
-
   let map_snd f x = Req.dimap Fun.id f x
 end
 
@@ -16,6 +15,7 @@ end
 
 module Via_dimap (Req : Preface_specs.Profunctor.WITH_DIMAP) =
   Core_via_dimap (Req)
+
 module Via_contramap_fst_and_map_snd
     (Req : Preface_specs.Profunctor.WITH_CONTRAMAP_FST_AND_MAP_SND) =
   Core_via_contramap_fst_and_map_snd (Req)
@@ -26,9 +26,7 @@ module From_functor (Functor : Preface_specs.Functor.CORE) = struct
   open Preface_core.Fun.Infix
 
   let dimap f g h = Functor.map g % h % f
-
   let contramap_fst k f = f % k
-
   let map_snd k f = Functor.map k % f
 end
 

--- a/lib/preface_make/reader.ml
+++ b/lib/preface_make/reader.ml
@@ -3,19 +3,13 @@ module Core_over_monad
     (Env : Preface_specs.Types.T0) =
 struct
   type env = Env.t
-
   type 'a monad = 'a Monad.t
-
   type 'a t = env -> 'a monad
 
   let upper m _ = m
-
   let run reader_m env = reader_m env
-
   let ask = Monad.return
-
   let local f reader x = reader (f x)
-
   let reader f = f
 end
 
@@ -33,7 +27,6 @@ Applicative.Via_apply (struct
   type 'a t = Env.t -> 'a A.t
 
   let pure x = Fun.const (A.pure x)
-
   let apply reader_f reader_v x = A.apply (reader_f x) (reader_v x)
 end)
 
@@ -46,7 +39,6 @@ module Alternative
          type 'a t = Env.t -> 'a A.t
 
          let neutral _ = A.neutral
-
          let combine reader_l reader_r r = A.combine (reader_l r) (reader_r r)
        end)
 
@@ -55,7 +47,6 @@ Monad.Via_bind (struct
   type 'a t = Env.t -> 'a M.t
 
   let return x = Fun.const (M.return x)
-
   let bind f reader r = M.bind (fun a -> (f a) r) (reader r)
 end)
 
@@ -66,7 +57,6 @@ module Monad_plus (M : Preface_specs.MONAD_PLUS) (Env : Preface_specs.Types.T0) 
          type 'a t = Env.t -> 'a M.t
 
          let neutral _ = M.neutral
-
          let combine reader_l reader_r r = M.combine (reader_l r) (reader_r r)
        end)
 

--- a/lib/preface_make/selective.ml
+++ b/lib/preface_make/selective.ml
@@ -28,7 +28,6 @@ struct
     type nonrec 'a t = 'a t
 
     let pure x = pure x
-
     let apply f x = select (map Either.left f) (map ( |> ) x)
   end
 
@@ -49,7 +48,6 @@ struct
     type nonrec 'a t = 'a t
 
     let pure x = pure x
-
     let apply f x = select (map Either.left f) (map ( |> ) x)
   end
 
@@ -90,11 +88,8 @@ module Operation (Core : Preface_specs.Selective.CORE) = struct
   ;;
 
   let bind_bool x f = if_ x (f false) (f true)
-
   let when_ predicate action = if_ predicate action (Core.pure ())
-
   let or_ left right = if_ left (Core.pure true) right
-
   let and_ left right = if_ left right (Core.pure false)
 
   let exists predicate =
@@ -123,9 +118,7 @@ struct
   include Applicative.Infix (Core) (Operation)
 
   let ( <*? ) e f = Core.select e f
-
   let ( <||> ) l r = Operation.or_ l r
-
   let ( <&&> ) l r = Operation.and_ l r
 end
 
@@ -210,7 +203,7 @@ module Select_from_monad (Monad : Preface_specs.MONAD) = struct
 
   let select xs fs =
     let open Monad.Infix in
-    xs >>= Preface_core.Shims.Either.case (fun a -> fs >|= (fun f -> f a)) pure
+    xs >>= Preface_core.Shims.Either.case (fun a -> fs >|= fun f -> f a) pure
   ;;
 end
 

--- a/lib/preface_make/semigroup.ml
+++ b/lib/preface_make/semigroup.ml
@@ -4,7 +4,6 @@ module Operation (Core : Preface_specs.Semigroup.CORE) = struct
   type t = Core.t
 
   let times_nel n x = Preface_core.Monoid.times_nel Core.combine n x
-
   let reduce_nel list = Preface_core.Monoid.reduce_nel Core.combine list
 end
 

--- a/lib/preface_make/semigroupoid.ml
+++ b/lib/preface_make/semigroupoid.ml
@@ -4,7 +4,6 @@ module Operation (Core : Preface_specs.Semigroupoid.CORE) = struct
   type ('a, 'b) t = ('a, 'b) Core.t
 
   let compose_right_to_left f g = Core.compose f g
-
   let compose_left_to_right f g = Core.compose g f
 end
 
@@ -12,13 +11,9 @@ module Infix (Core : Preface_specs.Semigroupoid.CORE) = struct
   type ('a, 'b) t = ('a, 'b) Core.t
 
   let ( % ) f g = Core.compose f g
-
   let ( <% ) f g = Core.compose f g
-
   let ( %> ) f g = Core.compose g f
-
   let ( <<< ) f g = Core.compose f g
-
   let ( >>> ) f g = Core.compose g f
 end
 

--- a/lib/preface_make/state.ml
+++ b/lib/preface_make/state.ml
@@ -3,27 +3,17 @@ module Core_over_monad
     (State : Preface_specs.Types.T0) =
 struct
   type state = State.t
-
   type 'a monad = 'a M.t
-
   type 'a t = state -> ('a * state) monad
 
   let upper m s = M.bind (fun a -> M.return (a, s)) m
-
   let state f x = M.return (f x)
-
   let eval m s = M.map fst (m s)
-
   let exec m s = M.map snd (m s)
-
   let run m s = m s
-
   let get s = state (fun s -> (s, s)) s
-
   let set s = state (fun _ -> ((), s))
-
   let modify f = state (fun s -> ((), f s))
-
   let gets f = state (fun s -> (f s, s))
 end
 
@@ -42,8 +32,8 @@ Applicative.Via_apply (struct
 
   let apply mf mx s =
     let open M in
-    let* (f, x) = mf s in
-    let+ (y, st) = mx x in
+    let* f, x = mf s in
+    let+ y, st = mx x in
     (f y, st)
   ;;
 end)
@@ -56,7 +46,7 @@ Monad.Via_bind (struct
 
   let bind f m s =
     let open M in
-    let* (v, st) = m s in
+    let* v, st = m s in
     f v st
   ;;
 end)
@@ -70,7 +60,6 @@ module Monad_plus
          type 'a t = State.t -> ('a * State.t) M.t
 
          let neutral _ = M.neutral
-
          let combine state_l state_r s = M.combine (state_l s) (state_r s)
        end)
 
@@ -83,7 +72,6 @@ module Alternative
          type 'a t = State.t -> ('a * State.t) M.t
 
          let neutral _ = M.neutral
-
          let combine state_l state_r s = M.combine (state_l s) (state_r s)
        end)
 

--- a/lib/preface_make/store.ml
+++ b/lib/preface_make/store.ml
@@ -3,7 +3,6 @@ module Core_over_comonad
     (Store : Preface_specs.Types.T0) =
 struct
   type store = Store.t
-
   type 'a comonad = 'a C.t
 
   let lower (f, s) = C.map (fun g -> g s) f
@@ -11,15 +10,10 @@ struct
   type 'a t = (store -> 'a) comonad * store
 
   let run (f, s) = (f, s)
-
   let pos (_, s) = s
-
   let peek s (g, _) = (C.extract g) s
-
   let peeks f (g, s) = (C.extract g) (f s)
-
   let seek s (f, _) = (f, s)
-
   let seeks f (g, s) = (g, f s)
 
   module Experiment (F : Preface_specs.FUNCTOR) = struct
@@ -32,7 +26,6 @@ Comonad.Via_extend (struct
   type 'a t = (Store.t -> 'a) C.t * Store.t
 
   let extract (g, s) = (C.extract g) s
-
   let extend f (g, s) = (C.extend (fun g' s' -> f (g', s')) g, s)
 end)
 

--- a/lib/preface_make/traced.ml
+++ b/lib/preface_make/traced.ml
@@ -3,23 +3,15 @@ module Core_over_comonad
     (Tape : Preface_specs.MONOID) =
 struct
   type tape = Tape.t
-
   type 'a comonad = 'a C.t
-
   type 'a t = (tape -> 'a) comonad
 
   let run f = f
-
   let lower f = (C.map (fun g -> g Tape.neutral)) f
-
   let trace t f = (C.extract f) t
-
   let traces f g = trace (f ((C.extract g) Tape.neutral)) g
-
   let listen t = run (C.map (fun f m -> (f m, m))) t
-
   let listens g t = run (C.map (fun f m -> (f m, g m))) t
-
   let censor g t = run (C.map (fun f x -> f (g x))) t
 end
 

--- a/lib/preface_make/traversable.ml
+++ b/lib/preface_make/traversable.ml
@@ -1,9 +1,11 @@
 open Preface_core.Fun
 module Core (Req : Preface_specs.Traversable.WITH_TRAVERSE) = Req
+
 module Core_over_applicative
     (A : Preface_specs.APPLICATIVE)
     (Req : Preface_specs.Traversable.WITH_TRAVERSE with type 'a t = 'a A.t) =
   Core (Req)
+
 module Core_over_monad
     (M : Preface_specs.MONAD)
     (Req : Preface_specs.Traversable.CORE with type 'a t = 'a M.t) =
@@ -11,7 +13,6 @@ module Core_over_monad
 
 module Operation (C : Preface_specs.Traversable.CORE) = struct
   type 'a t = 'a C.t
-
   type 'a iter = 'a C.iter
 
   let sequence x = C.traverse id x

--- a/lib/preface_make/writer.ml
+++ b/lib/preface_make/writer.ml
@@ -3,27 +3,17 @@ module Core_over_monad
     (Tape : Preface_specs.MONOID) =
 struct
   type tape = Tape.t
-
   type 'a monad = 'a Monad.t
-
   type 'a t = ('a * tape) monad
 
   let upper m = Monad.bind (fun a -> Monad.return (a, Tape.neutral)) m
-
   let writer (x, t) = Monad.return (x, t)
-
   let run writer_m = writer_m
-
   let exec x = Monad.map snd x
-
   let tell s = writer ((), s)
-
   let listen m = Monad.map (fun (x, b) -> ((x, b), b)) m
-
   let listens f m = Monad.map (fun (x, b) -> ((x, f b), b)) m
-
   let pass m = Monad.map (fun ((x, f), b) -> (x, f b)) m
-
   let censor f m = Monad.map (fun (x, b) -> (x, f b)) m
 end
 
@@ -53,7 +43,6 @@ module Alternative (A : Preface_specs.ALTERNATIVE) (Tape : Preface_specs.MONOID)
          type 'a t = ('a * Tape.t) A.t
 
          let neutral = A.neutral
-
          let combine writer_l writer_r = A.combine writer_l writer_r
        end)
 
@@ -64,7 +53,7 @@ Monad.Via_bind (struct
   let return x = M.return (x, Tape.neutral)
 
   let bind f m =
-    M.(m >>= (fun (x, t) -> f x >|= (fun (y, u) -> (y, Tape.combine t u))))
+    M.(m >>= fun (x, t) -> f x >|= fun (y, u) -> (y, Tape.combine t u))
   ;;
 end)
 
@@ -75,7 +64,6 @@ module Monad_plus (M : Preface_specs.MONAD_PLUS) (Tape : Preface_specs.MONOID) =
          type 'a t = ('a * Tape.t) M.t
 
          let neutral = M.neutral
-
          let combine writer_l writer_r = M.combine writer_l writer_r
        end)
 

--- a/lib/preface_specs/alternative.mli
+++ b/lib/preface_specs/alternative.mli
@@ -35,14 +35,12 @@ end
 (** Minimal definition using [neutral], [combine], [pure] and [apply]. *)
 module type WITH_APPLY = sig
   include Applicative.WITH_APPLY
-
   include WITH_NEUTRAL_AND_COMBINE with type 'a t := 'a t
 end
 
 (** Minimal definition using [neutral], [combine], [pure] and [lift2]. *)
 module type WITH_LIFT2 = sig
   include Applicative.WITH_LIFT2
-
   include WITH_NEUTRAL_AND_COMBINE with type 'a t := 'a t
 end
 

--- a/lib/preface_specs/category.mli
+++ b/lib/preface_specs/category.mli
@@ -26,7 +26,6 @@ module type WITH_ID_AND_COMPOSE = sig
   (** The type held by the [Category]. *)
 
   include WITH_ID with type ('a, 'b) t := ('a, 'b) t
-
   include Semigroupoid.WITH_COMPOSE with type ('a, 'b) t := ('a, 'b) t
 end
 

--- a/lib/preface_specs/decidable.mli
+++ b/lib/preface_specs/decidable.mli
@@ -40,7 +40,6 @@ end
     [choose]. *)
 module type WITH_CONTRAMAP_AND_DIVIDE_AND_CONQUER = sig
   include WITH_LOSE_AND_CHOOSE
-
   include Divisible.WITH_CONTRAMAP_AND_DIVIDE_AND_CONQUER with type 'a t := 'a t
 end
 

--- a/lib/preface_specs/divisible.mli
+++ b/lib/preface_specs/divisible.mli
@@ -13,9 +13,9 @@
         divide f (divide g m n) o
         = divide
             (fun x ->
-              let (bc, _) = f x in
-              let (b, c) = g bc in
-              (a, (b, c)))
+              let bc, _ = f x in
+              let b, c = g bc in
+              (a, (b, c)) )
             m (divide id n o)
       ]} *)
 
@@ -36,7 +36,6 @@ end
 
 module type WITH_CONTRAMAP_AND_DIVIDE_AND_CONQUER = sig
   include WITH_DIVIDE_AND_CONQUER
-
   include Contravariant.WITH_CONTRAMAP with type 'a t := 'a t
 end
 
@@ -51,7 +50,6 @@ module type OPERATION = sig
   (** The type held by the [Divisible]. *)
 
   val divided : 'a t -> 'b t -> ('a * 'b) t
-
   val conquered : unit t
 
   include Contravariant.OPERATION with type 'a t := 'a t

--- a/lib/preface_specs/freer_monad.mli
+++ b/lib/preface_specs/freer_monad.mli
@@ -18,7 +18,7 @@ module type CORE = sig
 
   type ('a, 'b) handle = ('a -> 'b) -> 'a f -> 'b
 
-  type 'a handler = { handler : 'b. ('b, 'a) handle}
+  type 'a handler = { handler : 'b. ('b, 'a) handle }
   (** The handler type. Which is a [Natural transformation] from the
       [Freer Monad] to an unwrapped [Identity monad]. *)
 

--- a/lib/preface_specs/freer_monad.mli
+++ b/lib/preface_specs/freer_monad.mli
@@ -16,7 +16,9 @@ module type CORE = sig
     | Return : 'a -> 'a t
     | Bind : 'b f * ('b -> 'a t) -> 'a t
 
-  type 'a handler = { handler : 'b. ('b -> 'a) -> 'b f -> 'a }
+  type ('a, 'b) handle = ('a -> 'b) -> 'a f -> 'b
+
+  type 'a handler = { handler : 'b. ('b, 'a) handle}
   (** The handler type. Which is a [Natural transformation] from the
       [Freer Monad] to an unwrapped [Identity monad]. *)
 

--- a/lib/preface_specs/monad_plus.mli
+++ b/lib/preface_specs/monad_plus.mli
@@ -27,7 +27,6 @@ end
     [compose_left_to_right]. *)
 module type WITH_KLEISLI_COMPOSITION = sig
   include Monad.WITH_KLEISLI_COMPOSITION
-
   include WITH_NEUTRAL_AND_COMBINE with type 'a t := 'a t
 end
 

--- a/lib/preface_specs/preface_specs.mli
+++ b/lib/preface_specs/preface_specs.mli
@@ -88,83 +88,44 @@ module Freer_monad = Freer_monad
     name in upper case. *)
 
 module type SEMIGROUP = Semigroup.API
-
 module type MONOID = Monoid.API
-
 module type FUNCTOR = Functor.API
-
 module type BIFUNCTOR = Bifunctor.API
-
 module type PROFUNCTOR = Profunctor.API
-
 module type STRONG = Strong.API
-
 module type CHOICE = Choice.API
-
 module type CLOSED = Closed.API
-
 module type APPLICATIVE = Applicative.API
-
 module type ALT = Alt.API
-
 module type ALTERNATIVE = Alternative.API
-
 module type SELECTIVE = Selective.API
-
 module type MONAD = Monad.API
-
 module type MONAD_PLUS = Monad_plus.API
-
 module type COMONAD = Comonad.API
-
 module type FOLDABLE = Foldable.API
-
 module type TRAVERSABLE = Traversable.API
-
 module type FREE_APPLICATIVE = Free_applicative.API
-
 module type FREE_SELECTIVE = Free_selective.API
-
 module type FREER_SELECTIVE = Freer_selective.API
-
 module type FREE_MONAD = Free_monad.API
-
 module type FREER_MONAD = Freer_monad.API
-
 module type INVARIANT = Invariant.API
-
 module type CONTRAVARIANT = Contravariant.API
-
 module type DIVISIBLE = Divisible.API
-
 module type SEMIGROUPOID = Semigroupoid.API
-
 module type DECIDABLE = Decidable.API
-
 module type CATEGORY = Category.API
-
 module type ARROW = Arrow.API
-
 module type ARROW_ZERO = Arrow_zero.API
-
 module type ARROW_ALT = Arrow_alt.API
-
 module type ARROW_PLUS = Arrow_plus.API
-
 module type ARROW_CHOICE = Arrow_choice.API
-
 module type ARROW_APPLY = Arrow_apply.API
-
 module type READER = Reader.API
-
 module type WRITER = Writer.API
-
 module type STATE = State.API
-
 module type STORE = Store.API
-
 module type ENV = Env.API
-
 module type TRACED = Traced.API
 
 (** {1 Types}

--- a/lib/preface_stdlib/approximation.ml
+++ b/lib/preface_stdlib/approximation.ml
@@ -5,7 +5,6 @@ module Over (M : Preface_specs.MONOID) = struct
     type nonrec 'a t = 'a t
 
     let pure _ = Over M.neutral
-
     let apply (Over x) (Over y) = Over M.(x <|> y)
   end)
 
@@ -28,7 +27,6 @@ module Under (M : Preface_specs.MONOID) = struct
     type nonrec 'a t = 'a t
 
     let pure _ = Under M.neutral
-
     let apply (Under x) (Under y) = Under M.(x <|> y)
   end)
 

--- a/lib/preface_stdlib/continuation.ml
+++ b/lib/preface_stdlib/continuation.ml
@@ -3,7 +3,6 @@ open Preface_core.Fun.Infix
 type 'a t = { run : 'r. ('a -> 'r) -> 'r }
 
 let pure c = { run = (fun k -> k c) }
-
 let map f c = { run = (fun k -> c.run @@ (f %> k)) }
 
 module Functor = Preface_make.Functor.Via_map (struct
@@ -16,7 +15,6 @@ module Applicative = Preface_make.Applicative.Via_map_and_product (struct
   type nonrec 'a t = 'a t
 
   let pure = pure
-
   let map = map
 
   let product ca cb =
@@ -28,9 +26,7 @@ module Monad = Preface_make.Monad.Via_map_and_join (struct
   type nonrec 'a t = 'a t
 
   let return = pure
-
   let map = map
-
   let join c = { run = (fun k -> c.run (fun c' -> c'.run k)) }
 end)
 

--- a/lib/preface_stdlib/either.ml
+++ b/lib/preface_stdlib/either.ml
@@ -28,7 +28,7 @@ module Alt (T : Preface_specs.Types.T0) =
        (struct
          type nonrec 'a t = (T.t, 'a) t
 
-         let combine x y = (match (x, y) with (Left _, a) -> a | (a, _) -> a)
+         let combine x y = match (x, y) with Left _, a -> a | a, _ -> a
        end)
 
 module Applicative (T : Preface_specs.Types.T0) = struct
@@ -40,7 +40,7 @@ module Applicative (T : Preface_specs.Types.T0) = struct
     let pure = pure
 
     let apply fa xa =
-      (match (fa, xa) with (Right f, x) -> F.map f x | (Left x, _) -> Left x)
+      match (fa, xa) with Right f, x -> F.map f x | Left x, _ -> Left x
     ;;
   end)
 
@@ -49,7 +49,6 @@ module Applicative (T : Preface_specs.Types.T0) = struct
       (A)
       (struct
         type 'a t = 'a A.t
-
         type 'a iter = (T.t, 'a) Bifunctor.t
 
         let traverse f x = traverse_aux A.pure A.map f x
@@ -63,7 +62,6 @@ module Monad (T : Preface_specs.Types.T0) = struct
     type nonrec 'a t = (T.t, 'a) t
 
     let return = pure
-
     let bind f = function Right x -> f x | Left x -> Left x
   end)
 
@@ -72,7 +70,6 @@ module Monad (T : Preface_specs.Types.T0) = struct
       (M)
       (struct
         type 'a t = 'a M.t
-
         type 'a iter = (T.t, 'a) Bifunctor.t
 
         let traverse f x = traverse_aux M.return M.map f x
@@ -88,13 +85,13 @@ module Foldable (T : Preface_specs.Types.T0) =
 Preface_make.Foldable.Via_fold_right (struct
   type nonrec 'a t = (T.t, 'a) t
 
-  let fold_right f x acc = (match x with Left _ -> acc | Right v -> f v acc)
+  let fold_right f x acc = match x with Left _ -> acc | Right v -> f v acc
 end)
 
 let equal f g left right =
   match (left, right) with
-  | (Left x, Left y) -> f x y
-  | (Right x, Right y) -> g x y
+  | Left x, Left y -> f x y
+  | Right x, Right y -> g x y
   | _ -> false
 ;;
 

--- a/lib/preface_stdlib/env.ml
+++ b/lib/preface_stdlib/env.ml
@@ -2,7 +2,6 @@ module Over (Env : Preface_specs.Types.T0) = struct
   include Preface_make.Env.Over_comonad (Identity.Comonad) (Env)
 
   let env e x = (e, Identity.pure x)
-
   let run_identity (e, x) = (e, Identity.extract x)
 
   module Functor = Preface_make.Env.Functor (Identity.Functor) (Env)

--- a/lib/preface_stdlib/exn.ml
+++ b/lib/preface_stdlib/exn.ml
@@ -3,7 +3,5 @@ type t = exn
 exception Negative_position of int
 
 let check_position x = if x < 0 then Error (Negative_position x) else Ok x
-
 let equal = ( = )
-
 let pp ppf exn = Format.fprintf ppf "%s" (Printexc.to_string exn)

--- a/lib/preface_stdlib/fun.ml
+++ b/lib/preface_stdlib/fun.ml
@@ -64,7 +64,6 @@ module Arrow_choice =
       open Preface_core.Shims
 
       let case f g = Either.fold ~left:f ~right:g
-
       let choose f g = case (Either.left % f) (Either.right % g)
     end)
 

--- a/lib/preface_stdlib/identity.ml
+++ b/lib/preface_stdlib/identity.ml
@@ -1,7 +1,6 @@
 type 'a t = 'a
 
 let pure x = x
-
 let extract x = x
 
 module Functor = Preface_make.Functor.Via_map (struct
@@ -14,7 +13,6 @@ module Applicative = Preface_make.Applicative.Via_apply (struct
   type nonrec 'a t = 'a t
 
   let pure = pure
-
   let apply f = f
 end)
 
@@ -22,7 +20,6 @@ module Monad = Preface_make.Monad.Via_bind (struct
   type nonrec 'a t = 'a t
 
   let return = pure
-
   let bind f = f
 end)
 
@@ -30,18 +27,16 @@ module Selective =
   Preface_make.Selective.Over_applicative_via_select
     (Applicative)
     (Preface_make.Selective.Select_from_monad (Monad))
+
 module Invariant = Preface_make.Invariant.From_functor (Functor)
 
 module Comonad = Preface_make.Comonad.Via_map_and_duplicate (struct
   type nonrec 'a t = 'a t
 
   let extract = extract
-
   let map f = f
-
   let duplicate x = x
 end)
 
 let equal f a b = f a b
-
 let pp pp' formater a = Format.fprintf formater "Identity (%a)" pp' a

--- a/lib/preface_stdlib/list.ml
+++ b/lib/preface_stdlib/list.ml
@@ -24,7 +24,6 @@ module Alternative = Preface_make.Alternative.Via_apply (struct
   ;;
 
   let neutral = []
-
   let combine l r = l @ r
 end)
 
@@ -33,7 +32,6 @@ module Applicative_traversable (A : Preface_specs.APPLICATIVE) =
     (A)
     (struct
       type 'a t = 'a A.t
-
       type 'a iter = 'a list
 
       let traverse f =
@@ -68,7 +66,6 @@ module Monad_plus = Preface_make.Monad_plus.Via_bind (struct
   ;;
 
   let neutral = []
-
   let combine l r = l @ r
 end)
 
@@ -77,7 +74,6 @@ module Monad_traversable (M : Preface_specs.MONAD) =
     (M)
     (struct
       type 'a t = 'a M.t
-
       type 'a iter = 'a list
 
       let traverse f =
@@ -92,10 +88,12 @@ module Monad_traversable (M : Preface_specs.MONAD) =
 
 module Monad =
   Preface_make.Traversable.Join_with_monad (Monad_plus) (Monad_traversable)
+
 module Selective =
   Preface_make.Selective.Over_applicative_via_select
     (Applicative)
     (Preface_make.Selective.Select_from_monad (Monad))
+
 module Invariant = Preface_make.Invariant.From_functor (Functor)
 
 module Monoid (T : Preface_specs.Types.T0) =
@@ -103,14 +101,13 @@ Preface_make.Monoid.Via_combine_and_neutral (struct
   type nonrec t = T.t t
 
   let combine l r = l @ r
-
   let neutral = []
 end)
 
 let equal f a b =
   let rec eq = function
-    | ([], []) -> true
-    | (x :: xs, y :: ys) -> f x y && eq (xs, ys)
+    | [], [] -> true
+    | x :: xs, y :: ys -> f x y && eq (xs, ys)
     | _ -> false
   in
   eq (a, b)

--- a/lib/preface_stdlib/nonempty_list.ml
+++ b/lib/preface_stdlib/nonempty_list.ml
@@ -33,7 +33,6 @@ module Applicative_internal = Preface_make.Applicative.Via_apply (struct
   type nonrec 'a t = 'a t
 
   let pure = pure
-
   let apply fs xs = flatten @@ map (fun f -> map (fun x -> f x) xs) fs
 end)
 
@@ -42,7 +41,6 @@ module Applicative_traversable (A : Preface_specs.APPLICATIVE) =
     (A)
     (struct
       type 'a t = 'a A.t
-
       type 'a iter = 'a Preface_core.Nonempty_list.t
 
       let traverse f l =
@@ -66,9 +64,7 @@ module Monad_internal = Preface_make.Monad.Via_map_and_join (struct
   type nonrec 'a t = 'a t
 
   let return = pure
-
   let map = map
-
   let join = flatten
 end)
 
@@ -77,7 +73,6 @@ module Monad_traversable (M : Preface_specs.MONAD) =
     (M)
     (struct
       type 'a t = 'a M.t
-
       type 'a iter = 'a Preface_core.Nonempty_list.t
 
       let traverse f l =
@@ -94,10 +89,12 @@ module Monad_traversable (M : Preface_specs.MONAD) =
 
 module Monad =
   Preface_make.Traversable.Join_with_monad (Monad_internal) (Monad_traversable)
+
 module Selective =
   Preface_make.Selective.Over_applicative_via_select
     (Applicative)
     (Preface_make.Selective.Select_from_monad (Monad))
+
 module Invariant = Preface_make.Invariant.From_functor (Functor)
 
 module Comonad = Preface_make.Comonad.Via_extend (struct
@@ -106,7 +103,7 @@ module Comonad = Preface_make.Comonad.Via_extend (struct
   let extract = function Last x | x :: _ -> x
 
   let rec extend f nel =
-    (match nel with Last _ -> Last (f nel) | _ :: xs -> f nel :: extend f xs)
+    match nel with Last _ -> Last (f nel) | _ :: xs -> f nel :: extend f xs
   ;;
 end)
 

--- a/lib/preface_stdlib/pair.ml
+++ b/lib/preface_stdlib/pair.ml
@@ -1,17 +1,11 @@
 type ('a, 'b) t = 'a * 'b
 
 let fst (x, _) = x
-
 let snd (_, x) = x
-
 let swap (x, y) = (y, x)
-
 let curry f x y = f (x, y)
-
 let uncurry f (x, y) = f x y
-
 let equal f g (x, y) (x', y') = f x x' && g y y'
-
 let pp f g formater (x, y) = Format.fprintf formater "(%a, %a)" f x g y
 
 module Infix = struct

--- a/lib/preface_stdlib/predicate.ml
+++ b/lib/preface_stdlib/predicate.ml
@@ -15,7 +15,7 @@ module Divisible =
       type nonrec 'a t = 'a t
 
       let divide f pa pb x =
-        let (a, b) = f x in
+        let a, b = f x in
         pa a && pb b
       ;;
 
@@ -36,20 +36,14 @@ module Decidable =
     end)
 
 let negate p x = not (p x)
-
 let tautology _ = true
-
 let contradiction _ = false
-
 let and_ l r x = l x && r x
-
 let or_ l r x = l x || r x
 
 module Infix = struct
   let ( && ) = and_
-
   let ( || ) = or_
-
   let ( ! ) = negate
 end
 

--- a/lib/preface_stdlib/reader.ml
+++ b/lib/preface_stdlib/reader.ml
@@ -1,8 +1,10 @@
 module Over (Env : Preface_specs.Types.T0) = struct
   include Preface_make.Reader.Over_monad (Identity.Monad) (Env)
   module Functor = Preface_make.Reader.Functor (Identity.Functor) (Env)
+
   module Applicative =
     Preface_make.Reader.Applicative (Identity.Applicative) (Env)
+
   module Invariant = Preface_make.Invariant.From_functor (Functor)
 
   let run_identity reader env = Identity.extract (run reader env)

--- a/lib/preface_stdlib/result.ml
+++ b/lib/preface_stdlib/result.ml
@@ -29,7 +29,7 @@ module Alt (T : Preface_specs.Types.T0) =
        (struct
          type nonrec 'a t = ('a, T.t) t
 
-         let combine x y = (match (x, y) with (Error _, a) -> a | (a, _) -> a)
+         let combine x y = match (x, y) with Error _, a -> a | a, _ -> a
        end)
 
 let traverse_aux pure map f = function
@@ -46,7 +46,7 @@ module Applicative (T : Preface_specs.Types.T0) = struct
     let pure = pure
 
     let apply fa xa =
-      (match (fa, xa) with (Ok f, x) -> F.map f x | (Error x, _) -> Error x)
+      match (fa, xa) with Ok f, x -> F.map f x | Error x, _ -> Error x
     ;;
   end)
 
@@ -55,7 +55,6 @@ module Applicative (T : Preface_specs.Types.T0) = struct
       (A)
       (struct
         type 'a t = 'a A.t
-
         type 'a iter = ('a, T.t) Bifunctor.t
 
         let traverse f x = traverse_aux A.pure A.map f x
@@ -69,7 +68,6 @@ module Monad (T : Preface_specs.Types.T0) = struct
     type nonrec 'a t = ('a, T.t) t
 
     let return = pure
-
     let bind f = function Ok x -> f x | Error x -> Error x
   end)
 
@@ -78,7 +76,6 @@ module Monad (T : Preface_specs.Types.T0) = struct
       (M)
       (struct
         type 'a t = 'a M.t
-
         type 'a iter = ('a, T.t) Bifunctor.t
 
         let traverse f x = traverse_aux M.return M.map f x
@@ -91,13 +88,13 @@ module Foldable (T : Preface_specs.Types.T0) =
 Preface_make.Foldable.Via_fold_right (struct
   type nonrec 'a t = ('a, T.t) t
 
-  let fold_right f x acc = (match x with Error _ -> acc | Ok v -> f v acc)
+  let fold_right f x acc = match x with Error _ -> acc | Ok v -> f v acc
 end)
 
 let equal f g left right =
   match (left, right) with
-  | (Ok x, Ok y) -> f x y
-  | (Error x, Error y) -> g x y
+  | Ok x, Ok y -> f x y
+  | Error x, Error y -> g x y
   | _ -> false
 ;;
 

--- a/lib/preface_stdlib/seq.ml
+++ b/lib/preface_stdlib/seq.ml
@@ -3,16 +3,15 @@ module S = Stdlib.Seq
 type 'a t = 'a S.t
 
 let pure x = S.return x
-
 let cons x xs () = S.Cons (x, xs)
 
 let rec append l r () =
-  (match l () with S.Nil -> r () | S.Cons (x, xs) -> S.Cons (x, append xs r))
+  match l () with S.Nil -> r () | S.Cons (x, xs) -> S.Cons (x, append xs r)
 ;;
 
 let rev seq =
   let rec aux acc seq =
-    (match seq () with S.Nil -> acc | S.Cons (x, xs) -> aux (cons x acc) xs)
+    match seq () with S.Nil -> acc | S.Cons (x, xs) -> aux (cons x acc) xs
   in
   aux S.empty seq
 ;;
@@ -27,7 +26,7 @@ module Alternative = Preface_make.Alternative.Via_apply (struct
 
   let apply fs xs =
     let rec aux a b () =
-      (match a () with S.Nil -> S.Nil | S.Cons (x, xs) -> merge xs b x b ())
+      match a () with S.Nil -> S.Nil | S.Cons (x, xs) -> merge xs b x b ()
     and merge a bs f b () =
       match b () with
       | S.Nil -> aux a bs ()
@@ -37,7 +36,6 @@ module Alternative = Preface_make.Alternative.Via_apply (struct
   ;;
 
   let neutral = S.empty
-
   let combine l r = append l r
 end)
 
@@ -46,7 +44,6 @@ module Applicative_traversable (A : Preface_specs.APPLICATIVE) =
     (A)
     (struct
       type 'a t = 'a A.t
-
       type 'a iter = 'a S.t
 
       let traverse f seq =
@@ -85,11 +82,8 @@ module Monad_plus = Preface_make.Monad_plus.Via_bind (struct
   type nonrec 'a t = 'a t
 
   let return = pure
-
   let bind = S.flat_map
-
   let neutral = S.empty
-
   let combine l r = append l r
 end)
 
@@ -98,7 +92,6 @@ module Monad_traversable (M : Preface_specs.MONAD) =
     (M)
     (struct
       type 'a t = 'a M.t
-
       type 'a iter = 'a S.t
 
       let traverse f =
@@ -114,6 +107,7 @@ module Monad_traversable (M : Preface_specs.MONAD) =
 
 module Monad =
   Preface_make.Traversable.Join_with_monad (Monad_plus) (Monad_traversable)
+
 module Selective =
   Preface_make.Selective.Over_applicative_via_select
     (Applicative)
@@ -124,16 +118,14 @@ Preface_make.Monoid.Via_combine_and_neutral (struct
   type nonrec t = T.t t
 
   let combine l r = append l r
-
   let neutral = S.empty
 end)
 
 let equal eq =
   let rec aux left right =
     match (left (), right ()) with
-    | (S.Nil, S.Nil) -> true
-    | (S.Cons (a, axs), S.Cons (b, bxs)) ->
-      if eq a b then aux axs bxs else false
+    | S.Nil, S.Nil -> true
+    | S.Cons (a, axs), S.Cons (b, bxs) -> if eq a b then aux axs bxs else false
     | _ -> false
   in
   aux

--- a/lib/preface_stdlib/state.ml
+++ b/lib/preface_stdlib/state.ml
@@ -2,9 +2,7 @@ module Over (State : Preface_specs.Types.T0) = struct
   include Preface_make.State.Over_monad (Identity.Monad) (State)
 
   let exec_identity m s = Identity.extract (exec m s)
-
   let eval_identity m s = Identity.extract (eval m s)
-
   let run_identity m s = Identity.extract (run m s)
 
   module Functor = Preface_make.State.Functor (Identity.Functor) (State)

--- a/lib/preface_stdlib/store.ml
+++ b/lib/preface_stdlib/store.ml
@@ -4,7 +4,7 @@ module Over (Store : Preface_specs.Types.T0) = struct
   let store f s = (Identity.pure f, s)
 
   let run_identity c =
-    let (f, s) = run c in
+    let f, s = run c in
     (Identity.extract f, s)
   ;;
 

--- a/lib/preface_stdlib/stream.ml
+++ b/lib/preface_stdlib/stream.ml
@@ -1,17 +1,11 @@
 type 'a t = C of 'a * 'a t Lazy.t
 
 let stream a l = C (a, l)
-
 let rec pure x = C (x, lazy (pure x))
-
 let repeat = pure
-
 let cons x s = C (x, lazy s)
-
 let hd = function C (x, _) -> x
-
 let tl = function C (_, xs) -> Lazy.force xs
-
 let rec map f = function C (x, xs) -> C (f x, lazy (map f @@ Lazy.force xs))
 
 module Functor = Preface_make.Functor.Via_map (struct
@@ -30,7 +24,7 @@ module Applicative = Preface_make.Applicative.Via_apply (struct
   let rec apply stream1 stream2 =
     let f g x = g x in
     match (stream1, stream2) with
-    | (C (x, xs), C (y, ys)) ->
+    | C (x, xs), C (y, ys) ->
       C (f x y, lazy (apply (Lazy.force xs) (Lazy.force ys)))
   ;;
 end)
@@ -39,7 +33,6 @@ module Monad = Preface_make.Monad.Via_map_and_join (struct
   type nonrec 'a t = 'a t
 
   let return = pure
-
   let map = map
 
   let rec join = function
@@ -108,7 +101,6 @@ let drop_while predicate stream =
 
 module Infix = struct
   let ( <:> ) = cons
-
   let ( .%[] ) s i = at i s
 end
 

--- a/lib/preface_stdlib/traced.ml
+++ b/lib/preface_stdlib/traced.ml
@@ -2,7 +2,6 @@ module Over (Tape : Preface_specs.MONOID) = struct
   include Preface_make.Traced.Over_comonad (Identity.Comonad) (Tape)
 
   let traced f = Identity.pure f
-
   let run_identity f x = (Identity.extract f) x
 
   module Functor = Preface_make.Traced.Functor (Identity.Functor) (Tape)

--- a/lib/preface_stdlib/try.ml
+++ b/lib/preface_stdlib/try.ml
@@ -1,9 +1,7 @@
 type 'a t = ('a, exn) Result.t
 
 let pure x = Ok x
-
 let ok = pure
-
 let error exn = Error exn
 
 module Functor = Result.Functor (struct
@@ -28,8 +26,7 @@ module Foldable = Result.Foldable (struct
   type t = exn
 end)
 
-let capture f = (try ok (f ()) with exn -> error exn)
-
+let capture f = try ok (f ()) with exn -> error exn
 let case f g = function Ok x -> f x | Error exn -> g exn
 
 let to_validation = function
@@ -38,5 +35,4 @@ let to_validation = function
 ;;
 
 let equal f = Result.equal f Exn.equal
-
 let pp pp' = Result.pp pp' Exn.pp

--- a/lib/preface_stdlib/validate.ml
+++ b/lib/preface_stdlib/validate.ml
@@ -1,11 +1,8 @@
 type 'a t = ('a, exn Nonempty_list.t) Validation.t
 
 let pure = Validation.pure
-
 let valid = Validation.valid
-
 let invalid = Validation.invalid
-
 let error err = invalid (Nonempty_list.create err)
 
 module Exn_list = Preface_make.Semigroup.From_alt (Nonempty_list.Alt) (Exn)
@@ -25,5 +22,4 @@ let to_result = function
 ;;
 
 let equal f = Validation.equal f (Nonempty_list.equal Exn.equal)
-
 let pp f = Validation.pp f (Nonempty_list.pp Exn.pp)

--- a/lib/preface_stdlib/validation.ml
+++ b/lib/preface_stdlib/validation.ml
@@ -3,11 +3,8 @@ type ('a, 'errors) t =
   | Invalid of 'errors
 
 let valid x = Valid x
-
 let invalid errors = Invalid errors
-
 let pure = valid
-
 let case f g = function Valid x -> f x | Invalid x -> g x
 
 module Bifunctor = Preface_make.Bifunctor.Via_bimap (struct
@@ -40,8 +37,8 @@ module Alt (Errors : Preface_specs.SEMIGROUP) =
 
          let combine a b =
            match (a, b) with
-           | (Invalid _, result) -> result
-           | (Valid x, _) -> Valid x
+           | Invalid _, result -> result
+           | Valid x, _ -> Valid x
          ;;
        end)
 
@@ -53,9 +50,9 @@ module Applicative (Errors : Preface_specs.SEMIGROUP) = struct
 
     let apply fx xs =
       match (fx, xs) with
-      | (Valid f, Valid x) -> Valid (f x)
-      | (Invalid left, Invalid right) -> Invalid (Errors.combine left right)
-      | (Invalid x, _) | (_, Invalid x) -> Invalid x
+      | Valid f, Valid x -> Valid (f x)
+      | Invalid left, Invalid right -> Invalid (Errors.combine left right)
+      | Invalid x, _ | _, Invalid x -> Invalid x
     ;;
   end)
 
@@ -64,7 +61,6 @@ module Applicative (Errors : Preface_specs.SEMIGROUP) = struct
       (A)
       (struct
         type 'a t = 'a A.t
-
         type 'a iter = ('a, Errors.t) Bifunctor.t
 
         let traverse f x = traverse_aux A.pure A.map f x
@@ -99,7 +95,6 @@ module Monad (T : Preface_specs.Types.T0) = struct
     type nonrec 'a t = ('a, T.t) t
 
     let return = valid
-
     let bind f = function Valid x -> f x | Invalid err -> Invalid err
   end)
 
@@ -108,7 +103,6 @@ module Monad (T : Preface_specs.Types.T0) = struct
       (M)
       (struct
         type 'a t = 'a M.t
-
         type 'a iter = ('a, T.t) Bifunctor.t
 
         let traverse f x = traverse_aux M.return M.map f x
@@ -122,14 +116,14 @@ Preface_make.Foldable.Via_fold_right (struct
   type nonrec 'a t = ('a, T.t) t
 
   let fold_right f validation x =
-    (match validation with Valid r -> f r x | Invalid _ -> x)
+    match validation with Valid r -> f r x | Invalid _ -> x
   ;;
 end)
 
 let equal f g left right =
   match (left, right) with
-  | (Valid x, Valid y) -> f x y
-  | (Invalid x, Invalid y) -> g x y
+  | Valid x, Valid y -> f x y
+  | Invalid x, Invalid y -> g x y
   | _ -> false
 ;;
 

--- a/lib/preface_stdlib/writer.ml
+++ b/lib/preface_stdlib/writer.ml
@@ -2,10 +2,10 @@ module Over (Tape : Preface_specs.MONOID) = struct
   include Preface_make.Writer.Over_monad (Identity.Monad) (Tape)
   module Functor = Preface_make.Writer.Functor (Identity.Functor) (Tape)
   module Invariant = Preface_make.Invariant.From_functor (Functor)
+
   module Applicative =
     Preface_make.Writer.Applicative (Identity.Applicative) (Tape)
 
   let run_identity x = Identity.extract (run x)
-
   let exec_identity x = Identity.extract (exec x)
 end

--- a/test/preface_examples_test/approximation_for_selective.ml
+++ b/test/preface_examples_test/approximation_for_selective.ml
@@ -2,7 +2,6 @@ module Monoid = Preface.Make.Monoid.Via_combine_and_neutral (struct
   type t = string
 
   let neutral = ""
-
   let combine x y = x ^ y
 end)
 

--- a/test/preface_examples_test/arrow_tutorial.ml
+++ b/test/preface_examples_test/arrow_tutorial.ml
@@ -19,9 +19,9 @@ module Circuit = struct
       {
         eval =
           (fun x ->
-            let (circuit1, b) = c1.eval x in
-            let (circuit2, c) = c2.eval b in
-            (compose circuit2 circuit1, c))
+            let circuit1, b = c1.eval x in
+            let circuit2, c = c2.eval b in
+            (compose circuit2 circuit1, c) )
       }
     ;;
   end)
@@ -38,8 +38,8 @@ module Circuit = struct
           {
             eval =
               (fun (a, b) ->
-                let (cir, c) = circuit.eval a in
-                (fst cir, (c, b)))
+                let cir, c = circuit.eval a in
+                (fst cir, (c, b)) )
           }
         ;;
       end)
@@ -55,9 +55,9 @@ module Circuit = struct
             eval =
               (function
               | Either.Left b ->
-                let (circuit', c) = origin.eval b in
+                let circuit', c = origin.eval b in
                 (left circuit', Either.Left c)
-              | Either.Right d -> (left origin, Either.Right d))
+              | Either.Right d -> (left origin, Either.Right d) )
           }
         ;;
       end)
@@ -65,7 +65,7 @@ module Circuit = struct
   let rec run circuit = function
     | [] -> []
     | x :: xs ->
-      let (cir, a) = circuit.eval x in
+      let cir, a = circuit.eval x in
       a :: run cir xs
   ;;
 
@@ -73,8 +73,8 @@ module Circuit = struct
     {
       eval =
         (fun input ->
-          let (output, aux) = f input acc in
-          (fold aux f, output))
+          let output, aux = f input acc in
+          (fold aux f, output) )
     }
   ;;
 
@@ -86,7 +86,6 @@ module Circuit = struct
 end
 
 let total = Circuit.reduce 0 ( + )
-
 let total_float = Circuit.reduce 0. ( +. )
 
 let total_test () =

--- a/test/preface_examples_test/debruijn_reader.ml
+++ b/test/preface_examples_test/debruijn_reader.ml
@@ -19,9 +19,9 @@ module DeBruijn = struct
 
   let rec equal f d1 d2 =
     match (d1, d2) with
-    | (App (d11, d12), App (d21, d22)) -> equal f d11 d21 && equal f d12 d22
-    | (Abs d11, Abs d22) -> equal f d11 d22
-    | (Var i1, Var i2) -> f i1 i2
+    | App (d11, d12), App (d21, d22) -> equal f d11 d21 && equal f d12 d22
+    | Abs d11, Abs d22 -> equal f d11 d22
+    | Var i1, Var i2 -> f i1 i2
     | _ -> false
   ;;
 end

--- a/test/preface_examples_test/decidable_pp.ml
+++ b/test/preface_examples_test/decidable_pp.ml
@@ -16,7 +16,6 @@ module Printer = struct
   type 'a t = 'a -> string
 
   let string = Fun.id
-
   let const s = Fun.const s
 
   let of_pp (type a) (module P : PP with type t = a) x =
@@ -24,7 +23,6 @@ module Printer = struct
   ;;
 
   let int = of_pp (module I)
-
   let nl = const "\n"
 
   open Preface.Fun.Infix
@@ -44,7 +42,7 @@ module Printer = struct
         let conquer x = Fun.const "" x
 
         let divide f x y c =
-          let (a, b) = f c in
+          let a, b = f c in
           x a ^ y b
         ;;
       end)
@@ -56,7 +54,6 @@ module Printer = struct
         type nonrec 'a t = 'a t
 
         let lose f x = Preface.Void.absurd (f x)
-
         let choose f x y c = Either.fold ~left:x ~right:y (f c)
       end)
 

--- a/test/preface_examples_test/formlet.ml
+++ b/test/preface_examples_test/formlet.ml
@@ -19,9 +19,7 @@ module Formlet = struct
   ;;
 
   exception Invalid_age of int
-
   exception Invalid_name of (string * string)
-
   exception Unchecked_rules
 
   let validate_age age =

--- a/test/preface_examples_test/free_applicative_formlet.ml
+++ b/test/preface_examples_test/free_applicative_formlet.ml
@@ -1,7 +1,5 @@
 exception Invalid_int of string
-
 exception Missing_field of string
-
 exception String_shorter of (string * int)
 
 let err = Preface.Nonempty_list.create
@@ -22,7 +20,7 @@ module Functor = Preface.Make.Functor.Via_map (struct
           let open Preface.Validation in
           match env.parser x with
           | Invalid x -> Invalid x
-          | Valid value -> Valid (f value))
+          | Valid value -> Valid (f value) )
     }
   ;;
 end)
@@ -50,9 +48,7 @@ let string_with_len potential_len value =
 module Free = Preface.Make.Free_applicative.Over_functor (Functor)
 
 let field name reader = Free.promote (parser reader name)
-
 let string ?len name = field name (string_with_len len)
-
 let int name = field name read_int
 
 module Run = Free.To_applicative (Preface.Validate.Applicative)
@@ -61,7 +57,6 @@ module Count = Free.To_monoid (struct
   type t = int
 
   let neutral = 0
-
   let combine x y = x + y
 end)
 

--- a/test/preface_examples_test/free_monad_consoleIO.ml
+++ b/test/preface_examples_test/free_monad_consoleIO.ml
@@ -10,8 +10,8 @@ module ConsoleIO = struct
 
     let map f x =
       match x with
-      | Tell (s, k) -> Tell (s, (fun () -> f (k ())))
-      | Ask (s, k) -> Ask (s, (fun s -> f (k s)))
+      | Tell (s, k) -> Tell (s, fun () -> f (k ()))
+      | Ask (s, k) -> Ask (s, fun s -> f (k s))
     ;;
   end)
 end
@@ -19,7 +19,6 @@ end
 module IO = Preface_make.Free_monad.Over_functor (ConsoleIO.Functor)
 
 let tell x = IO.perform (ConsoleIO.Tell (x, id))
-
 let ask s = IO.perform (ConsoleIO.Ask (s, id))
 
 let runConsoleIO output = function

--- a/test/preface_examples_test/free_monad_consoleIO_composition.ml
+++ b/test/preface_examples_test/free_monad_consoleIO_composition.ml
@@ -6,9 +6,7 @@ module Tell = struct
   module Functor = Preface.Make.Functor.Via_map (struct
     type nonrec 'a t = 'a t
 
-    let map f x =
-      (match x with Effect (s, k) -> Effect (s, (fun () -> f (k ()))))
-    ;;
+    let map f x = match x with Effect (s, k) -> Effect (s, fun () -> f (k ()))
   end)
 end
 
@@ -18,9 +16,7 @@ module Ask = struct
   module Functor = Preface.Make.Functor.Via_map (struct
     type nonrec 'a t = 'a t
 
-    let map f x =
-      (match x with Effect (s, k) -> Effect (s, (fun s -> f (k s))))
-    ;;
+    let map f x = match x with Effect (s, k) -> Effect (s, fun s -> f (k s))
   end)
 end
 
@@ -28,7 +24,6 @@ module ConsoleIO = Preface.Make.Functor.Sum (Ask.Functor) (Tell.Functor)
 module IO = Preface_make.Free_monad.Over_functor (ConsoleIO)
 
 let tell x = IO.perform (ConsoleIO.R (Tell.Effect (x, id)))
-
 let ask s = IO.perform (ConsoleIO.L (Ask.Effect (s, id)))
 
 let runConsoleIO output = function

--- a/test/preface_examples_test/free_selective_pingpong.ml
+++ b/test/preface_examples_test/free_selective_pingpong.ml
@@ -30,7 +30,6 @@ module IO = struct
   end)
 
   let get_line = perform IORead
-
   let put_line s = perform (IOWrite s)
 
   module Selective =
@@ -43,7 +42,6 @@ module Free = struct
   include Preface.Make.Free_selective.Over_functor (Functor)
 
   let get_line = promote (Read Fun.id)
-
   let put_line s = promote (Write (s, ()))
 end
 
@@ -97,7 +95,7 @@ let test_when_read_returns_ping () =
                 let () = state := !state @ [ "Read" ] in
                 resume "ping"
             in
-            f resume effect)
+            f resume effect )
       }
       (free_to_io ping_pong)
   in
@@ -121,7 +119,7 @@ let test_when_read_returns_something_else () =
                 let () = state := !state @ [ "Read" ] in
                 resume "not_ping"
             in
-            f resume effect)
+            f resume effect )
       }
       (free_to_io ping_pong)
   in

--- a/test/preface_examples_test/freer_monad_consoleIO.ml
+++ b/test/preface_examples_test/freer_monad_consoleIO.ml
@@ -9,7 +9,6 @@ end
 module IO = Preface.Make.Freer_monad.Over (ConsoleIO)
 
 let tell x = IO.perform (ConsoleIO.Tell (x, id))
-
 let ask s = IO.perform (ConsoleIO.Ask (s, id))
 
 let runConsoleIO output sk = function

--- a/test/preface_examples_test/freer_monad_os_effect.ml
+++ b/test/preface_examples_test/freer_monad_os_effect.ml
@@ -14,7 +14,6 @@ module Effect = struct
   end)
 
   let get_home = perform Get_home
-
   let print message = perform (Print message)
 
   let program path =
@@ -52,7 +51,7 @@ let happy_path_without_path () =
                 let () = record output "get_home" in
                 resume "/xhtmlboi"
             in
-            f resume effect)
+            f resume effect )
       }
       (program None)
   in
@@ -78,7 +77,7 @@ let happy_path_with_path () =
                 let () = record output "get_home" in
                 resume "/xhtmlboi"
             in
-            f resume effect)
+            f resume effect )
       }
       (program (Some "./a-path"))
   in
@@ -104,7 +103,7 @@ let unhappy_path_without_path () =
                 let () = record output "get_home" in
                 Preface.Try.error No_home
             in
-            f resume effect)
+            f resume effect )
       }
       (program None)
   in

--- a/test/preface_examples_test/freer_monad_os_explicit_continuation.ml
+++ b/test/preface_examples_test/freer_monad_os_explicit_continuation.ml
@@ -14,7 +14,6 @@ module Effect = struct
   end)
 
   let get_home = perform (Get_home Fun.id)
-
   let print message = perform (Print (message, Fun.id))
 
   let program path =
@@ -48,7 +47,7 @@ let happy_path_without_path () =
               resume (k ())
             | Get_home k ->
               let () = record output "get_home" in
-              resume (k "/xhtmlboi"))
+              resume (k "/xhtmlboi") )
       }
       (program None)
   in
@@ -70,7 +69,7 @@ let happy_path_with_path () =
               resume (k ())
             | Get_home k ->
               let () = record output "get_home" in
-              resume (k "/xhtmlboi"))
+              resume (k "/xhtmlboi") )
       }
       (program (Some "./a-path"))
   in
@@ -92,7 +91,7 @@ let unhappy_path_without_path () =
               resume (k ())
             | Get_home _ ->
               let () = record output "get_home" in
-              Preface.Try.error No_home)
+              Preface.Try.error No_home )
       }
       (program None)
   in

--- a/test/preface_examples_test/freer_selective_ping_pong.ml
+++ b/test/preface_examples_test/freer_selective_ping_pong.ml
@@ -12,7 +12,6 @@ module IO = struct
   end)
 
   let get_line = perform IORead
-
   let put_line s = perform (IOWrite s)
 
   module Selective =
@@ -27,7 +26,6 @@ module Freer = struct
   end)
 
   let get_line = promote Read
-
   let put_line s = promote (Write s)
 end
 
@@ -66,7 +64,7 @@ let test_when_read_returns_ping () =
                 let () = state := !state @ [ "Read" ] in
                 resume "ping"
             in
-            f resume effect)
+            f resume effect )
       }
       (free_to_io ping_pong)
   in
@@ -90,7 +88,7 @@ let test_when_read_returns_something_else () =
                 let () = state := !state @ [ "Read" ] in
                 resume "not_ping"
             in
-            f resume effect)
+            f resume effect )
       }
       (free_to_io ping_pong)
   in

--- a/test/preface_examples_test/shape.ml
+++ b/test/preface_examples_test/shape.ml
@@ -5,9 +5,7 @@
 
 module Shape = struct
   type radius = int
-
   type width = int
-
   type height = int
 
   type shape =
@@ -16,8 +14,8 @@ module Shape = struct
 
   let eq l r =
     match (l, r) with
-    | (Circle x, Circle y) -> x = y
-    | (Rectangle (w, h), Rectangle (w2, h2)) -> w = w2 && h = h2
+    | Circle x, Circle y -> x = y
+    | Rectangle (w, h), Rectangle (w2, h2) -> w = w2 && h = h2
     | _ -> false
   ;;
 
@@ -29,7 +27,6 @@ module Shape = struct
   exception Fail of string
 
   let circle r = Circle r
-
   let rectangle w h = Rectangle (w, h)
 
   let make choice r w h =

--- a/test/preface_examples_test/traced_dependencies.ml
+++ b/test/preface_examples_test/traced_dependencies.ml
@@ -10,7 +10,6 @@ let dependencies_of = function
 ;;
 
 let f = Preface.List.Foldable.fold_map (module S) dependencies_of
-
 let direct_deps = D.traced f
 
 let deps subject =

--- a/test/preface_examples_test/xml_stax_writer.ml
+++ b/test/preface_examples_test/xml_stax_writer.ml
@@ -20,9 +20,9 @@ module Stax = struct
 
   let equal f d1 d2 =
     match (d1, d2) with
-    | (Text t1, Text t2) -> f t1 t2
-    | (Open t1, Open t2) -> f t1 t2
-    | (Close t1, Close t2) -> f t1 t2
+    | Text t1, Text t2 -> f t1 t2
+    | Open t1, Open t2 -> f t1 t2
+    | Close t1, Close t2 -> f t1 t2
     | _ -> false
   ;;
 end
@@ -56,21 +56,21 @@ let sax = Alcotest.testable Stax.pp (Stax.equal ( = ))
 let should_transform_a_pcdata () =
   let open Writer in
   let expected = Stax.[ Text "Hello World" ]
-  and (_, computed) = run_identity (sax_like Xml.(PCData "Hello World")) in
+  and _, computed = run_identity (sax_like Xml.(PCData "Hello World")) in
   Alcotest.(check (list sax)) "transform_a_pcdata" expected computed
 ;;
 
 let should_transform_a_tag () =
   let open Writer in
   let expected = Stax.[ Open "A"; Close "A" ]
-  and (_, computed) = run_identity (sax_like Xml.(Tag ("A", Empty))) in
+  and _, computed = run_identity (sax_like Xml.(Tag ("A", Empty))) in
   Alcotest.(check (list sax)) "transform_a_tag" expected computed
 ;;
 
 let should_transform_a_sequence () =
   let open Writer in
   let expected = Stax.[ Open "A"; Close "A"; Text "Hello World" ]
-  and (_, computed) =
+  and _, computed =
     run_identity (sax_like Xml.(Seq (Tag ("A", Empty), PCData "Hello World")))
   in
   Alcotest.(check (list sax)) "transform_a_sequence" expected computed
@@ -79,7 +79,7 @@ let should_transform_a_sequence () =
 let should_transform_empty () =
   let open Writer in
   let expected = []
-  and (_, computed) = run_identity (sax_like Xml.Empty) in
+  and _, computed = run_identity (sax_like Xml.Empty) in
   Alcotest.(check (list sax)) "transform_empty" expected computed
 ;;
 

--- a/test/preface_laws/alt.ml
+++ b/test/preface_laws/alt.ml
@@ -10,8 +10,6 @@ module Semigroup_cases
          type t = T.A.t F.t
 
          let equal = A.equal T.A.equal
-
          let arbitrary = A.arbitrary T.A.arbitrary
-
          let observable = A.observable T.A.observable
        end)

--- a/test/preface_laws/alternative.ml
+++ b/test/preface_laws/alternative.ml
@@ -44,15 +44,11 @@ Preface_qcheck.Make.Test (struct
   let name = "neutral <*> a = neutral"
 
   type input = X.t F.t
-
   type output = X.t F.t
 
   let arbitrary = A.arbitrary X.arbitrary
-
   let equal = A.equal X.equal
-
   let left x = F.(neutral <*> x)
-
   let right _ = F.neutral
 end)
 
@@ -66,9 +62,7 @@ module Monoidal_behaviour
          type t = X.t F.t
 
          let equal = A.equal X.equal
-
          let arbitrary = A.arbitrary X.arbitrary
-
          let observable = A.observable X.observable
        end)
 

--- a/test/preface_laws/applicative.ml
+++ b/test/preface_laws/applicative.ml
@@ -8,15 +8,11 @@ Preface_qcheck.Make.Test (struct
   let name = "pure id <*> x = x"
 
   type input = X.t F.t
-
   type output = input
 
   let arbitrary = A.arbitrary X.arbitrary
-
   let equal = A.equal X.equal
-
   let left x = F.(pure (fun x -> x) <*> x)
-
   let right x = x
 end)
 
@@ -29,11 +25,9 @@ Preface_qcheck.Make.Test (struct
   let name = "pure f <*> pure x = pure (f x)"
 
   type input = X.t * (X.t -> Y.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary = QCheck.(pair X.arbitrary (fun1 X.observable Y.arbitrary))
-
   let equal = A.equal Y.equal
 
   let left (x, f') =
@@ -56,7 +50,6 @@ Preface_qcheck.Make.Test (struct
   let name = "f <*> pure x = pure ((|>) x) <*> f"
 
   type input = X.t * (X.t -> Y.t) QCheck.fun_ F.t
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -123,7 +116,6 @@ Preface_qcheck.Make.Test (struct
   let name = "fmap f x = pure f <*> x"
 
   type input = X.t F.t * (X.t -> Y.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -151,15 +143,11 @@ Preface_qcheck.Make.Test (struct
   let name = "u *> v = (id <$ u) <*> v"
 
   type input = X.t F.t
-
   type output = input
 
   let arbitrary = A.arbitrary X.arbitrary
-
   let equal = A.equal X.equal
-
   let left x = F.(pure () *> x)
-
   let right x = F.((fun x -> x) <$ pure () <*> x)
 end)
 
@@ -171,20 +159,17 @@ Preface_qcheck.Make.Test (struct
   let name = "u <* v = lift2 const u v"
 
   type input = X.t F.t
-
   type output = input
 
   let arbitrary = A.arbitrary X.arbitrary
-
   let equal = A.equal X.equal
-
   let left x = F.(x <* pure ())
-
   let right x = F.(lift2 Preface_core.Fun.const x (pure ()))
 end)
 
 module Preserve_functor_identity (A : Preface_specs.APPLICATIVE) =
   Functor.Preserve_identity (A)
+
 module Preserve_functor_morphism (A : Preface_specs.APPLICATIVE) =
   Functor.Preserve_morphism (A)
 

--- a/test/preface_laws/arrow.ml
+++ b/test/preface_laws/arrow.ml
@@ -4,43 +4,37 @@ module type LAWS = sig
   include Category.LAWS
 
   val law1 : string * (unit -> ('a, 'a) t pair)
-
   val law2 : string * (('a -> 'b) -> ('b -> 'c) -> ('a, 'c) t pair)
-
   val law3 : string * (('a -> 'b) -> ('a * 'c, 'b * 'c) t pair)
-
   val law4 : string * (('a, 'b) t -> ('b, 'c) t -> ('a * 'd, 'c * 'd) t pair)
-
   val law5 : string * (('a, 'b) t -> ('c -> 'd) -> ('a * 'c, 'b * 'd) t pair)
-
   val law6 : string * (('a, 'b) t -> ('a * 'c, 'b) t pair)
-
   val law7 : string * (('a, 'b) t -> (('a * 'c) * 'd, 'b * ('c * 'd)) t pair)
 end
 
 module Laws (A : Preface_specs.ARROW) = struct
   include Category.Laws (A)
 
-  let law1 = ("arrow id = id", (fun () -> (A.arrow (fun x -> x), A.id)))
+  let law1 = ("arrow id = id", fun () -> (A.arrow (fun x -> x), A.id))
 
   let law2 =
     let left f g =
       let h = Preface_core.Fun.(g % f) in
       A.(arrow h)
     and right f g = A.(arrow f >>> arrow g) in
-    ("arrow (g % f) = arrow f >>> arrow g", (fun f g -> (left f g, right f g)))
+    ("arrow (g % f) = arrow f >>> arrow g", fun f g -> (left f g, right f g))
   ;;
 
   let law3 =
     let left f = A.(fst (arrow f))
     and right f = A.arrow (fun (x, y) -> (f x, y)) in
-    ("fst (arrow f) = arr (fst f)", (fun f -> (left f, right f)))
+    ("fst (arrow f) = arr (fst f)", fun f -> (left f, right f))
   ;;
 
   let law4 =
     let left f g = A.(fst (f >>> g))
     and right f g = A.(fst f >>> fst g) in
-    ("fst (f >>> g) = fst f >>> fst g", (fun f g -> (left f g, right f g)))
+    ("fst (f >>> g) = fst f >>> fst g", fun f g -> (left f g, right f g))
   ;;
 
   let law5 =
@@ -48,14 +42,14 @@ module Laws (A : Preface_specs.ARROW) = struct
     and right f g = A.(arrow (fun (x, y) -> (x, g y)) >>> fst f) in
     ( "fst f >>> arrow (fun (x,y) -> (x,g y)) = arrow (fun (x,y) -> (x,g y)) \
        >>> fst f"
-    , (fun f g -> (left f g, right f g)) )
+    , fun f g -> (left f g, right f g) )
   ;;
 
   let law6 =
     let left f = A.(fst f >>> arrow Stdlib.fst)
     and right f = A.(arrow Stdlib.fst >>> f) in
     ( "fst f >>> arrow Stdlib.fst = arrow Stdlib.fst >>> f"
-    , (fun f -> (left f, right f)) )
+    , fun f -> (left f, right f) )
   ;;
 
   let law7 =
@@ -63,6 +57,6 @@ module Laws (A : Preface_specs.ARROW) = struct
     let left f = A.(fst (fst f) >>> arrow assoc)
     and right f = A.(arrow assoc >>> fst f) in
     ( "fst (fst f) >>> arrow assoc = arrow assoc >>> fst f"
-    , (fun f -> (left f, right f)) )
+    , fun f -> (left f, right f) )
   ;;
 end

--- a/test/preface_laws/arrow.mli
+++ b/test/preface_laws/arrow.mli
@@ -6,17 +6,11 @@ module type LAWS = sig
   include Category.LAWS
 
   val law1 : string * (unit -> ('a, 'a) t pair)
-
   val law2 : string * (('a -> 'b) -> ('b -> 'c) -> ('a, 'c) t pair)
-
   val law3 : string * (('a -> 'b) -> ('a * 'c, 'b * 'c) t pair)
-
   val law4 : string * (('a, 'b) t -> ('b, 'c) t -> ('a * 'd, 'c * 'd) t pair)
-
   val law5 : string * (('a, 'b) t -> ('c -> 'd) -> ('a * 'c, 'b * 'd) t pair)
-
   val law6 : string * (('a, 'b) t -> ('a * 'c, 'b) t pair)
-
   val law7 : string * (('a, 'b) t -> (('a * 'c) * 'd, 'b * ('c * 'd)) t pair)
 end
 

--- a/test/preface_laws/arrow_apply.ml
+++ b/test/preface_laws/arrow_apply.ml
@@ -4,9 +4,7 @@ module type LAWS = sig
   include Arrow.LAWS
 
   val law8 : string * (unit -> ('a * 'b, 'a * 'b) t pair)
-
   val law9 : string * (('a, 'b) t -> (('b, 'c) t * 'a, 'c) t pair)
-
   val law10 : string * (('a, 'b) t -> (('c, 'a) t * 'c, 'b) t pair)
 end
 
@@ -17,20 +15,20 @@ module Laws (A : Preface_specs.ARROW_APPLY) = struct
     let lhs () = A.(fst (arrow (fun x -> arrow (fun y -> (x, y)))) >>> apply) in
     let rhs () = A.id in
     ( "fst (arrow (fun x -> arrow (fun y -> (x,y)))) >>> apply = id"
-    , (fun () -> (lhs (), rhs ())) )
+    , fun () -> (lhs (), rhs ()) )
   ;;
 
   let law9 =
     let lhs g = A.(fst (arrow (fun x -> g >>> x)) >>> apply) in
     let rhs g = A.(snd g >>> apply) in
     ( "fst (arrow (fun x -> g >>> x)) >>> apply = snd g >>> apply"
-    , (fun g -> (lhs g, rhs g)) )
+    , fun g -> (lhs g, rhs g) )
   ;;
 
   let law10 =
     let lhs h = A.(fst (arrow (fun x -> x >>> h)) >>> apply) in
     let rhs h = A.(apply >>> h) in
     ( "fst (arrow (fun x -> x >>> h)) >>> apply = apply >>> h"
-    , (fun h -> (lhs h, rhs h)) )
+    , fun h -> (lhs h, rhs h) )
   ;;
 end

--- a/test/preface_laws/arrow_apply.mli
+++ b/test/preface_laws/arrow_apply.mli
@@ -4,9 +4,7 @@ module type LAWS = sig
   include Arrow.LAWS
 
   val law8 : string * (unit -> ('a * 'b, 'a * 'b) t pair)
-
   val law9 : string * (('a, 'b) t -> (('b, 'c) t * 'a, 'c) t pair)
-
   val law10 : string * (('a, 'b) t -> (('c, 'a) t * 'c, 'b) t pair)
 end
 

--- a/test/preface_laws/arrow_choice.ml
+++ b/test/preface_laws/arrow_choice.ml
@@ -37,32 +37,32 @@ module Laws (A : Preface_specs.ARROW_CHOICE) = struct
   let law8 =
     let lhs f = A.(left (arrow f)) in
     let rhs f = A.(arrow f +++ id) in
-    ("left (arrow f) = arrow (f ++ id)", (fun f -> (lhs f, rhs f)))
+    ("left (arrow f) = arrow (f ++ id)", fun f -> (lhs f, rhs f))
   ;;
 
   let law9 =
     let lhs f g = A.(left (f >>> g)) in
     let rhs f g = A.(left f >>> left g) in
-    ("left (f >>> g) = left f >>> left g", (fun f g -> (lhs f g, rhs f g)))
+    ("left (f >>> g) = left f >>> left g", fun f g -> (lhs f g, rhs f g))
   ;;
 
   let law10 =
     let lhs f = A.(f >>> arrow Either.left) in
     let rhs f = A.(arrow Either.left >>> left f) in
-    ("f >>> arr Left = arr Left >>> left f", (fun f -> (lhs f, rhs f)))
+    ("f >>> arr Left = arr Left >>> left f", fun f -> (lhs f, rhs f))
   ;;
 
   let law11 =
     let lhs f g = A.(left f >>> arrow (prod Fun.id g)) in
     let rhs f g = A.(arrow (prod Fun.id g) >>> left f) in
     ( "left f >>> arrow (Fun.id +++ g) = arrow (Fun.id +++ g) >>> left f"
-    , (fun f g -> (lhs f g, rhs f g)) )
+    , fun f g -> (lhs f g, rhs f g) )
   ;;
 
   let law12 =
     let lhs f = A.(left (left f) >>> arrow assoc) in
     let rhs f = A.(arrow assoc >>> left f) in
     ( "left (left f) >>> arrow assocsum = arrow assocsum >>> left f"
-    , (fun f -> (lhs f, rhs f)) )
+    , fun f -> (lhs f, rhs f) )
   ;;
 end

--- a/test/preface_laws/bifunctor.ml
+++ b/test/preface_laws/bifunctor.ml
@@ -9,15 +9,11 @@ Preface_qcheck.Make.Test (struct
   let name = "bimap id id = id"
 
   type input = (X.t, Y.t) F.t
-
   type output = input
 
   let arbitrary = A.arbitrary X.arbitrary Y.arbitrary
-
   let equal = A.equal X.equal Y.equal
-
   let left x = F.bimap (fun x -> x) (fun x -> x) x
-
   let right x = (fun x -> x) x
 end)
 
@@ -30,15 +26,11 @@ Preface_qcheck.Make.Test (struct
   let name = "map_fst id = id"
 
   type input = (X.t, Y.t) F.t
-
   type output = input
 
   let arbitrary = A.arbitrary X.arbitrary Y.arbitrary
-
   let equal = A.equal X.equal Y.equal
-
   let left x = F.map_fst (fun x -> x) x
-
   let right x = (fun x -> x) x
 end)
 
@@ -51,15 +43,11 @@ Preface_qcheck.Make.Test (struct
   let name = "map_snd id = id"
 
   type input = (X.t, Y.t) F.t
-
   type output = input
 
   let arbitrary = A.arbitrary X.arbitrary Y.arbitrary
-
   let equal = A.equal X.equal Y.equal
-
   let left x = F.map_snd (fun x -> x) x
-
   let right x = (fun x -> x) x
 end)
 
@@ -239,8 +227,10 @@ struct
   module First = Perserve_first (F) (A) (T.A) (T.B)
   module Second = Perserve_second (F) (A) (T.A) (T.B)
   module Bimap_fst_snd = Bimap_fst_snd (F) (A) (T.A) (T.B) (T.C) (T.D)
+
   module Bimap_parametricity =
     Bimap_parametricity (F) (A) (T.A) (T.B) (T.C) (T.D) (T.E) (T.F)
+
   module Fst_parametricity = Fst_parametricity (F) (A) (T.A) (T.B) (T.C) (T.D)
   module Snd_parametricity = Snd_parametricity (F) (A) (T.A) (T.B) (T.C) (T.D)
 

--- a/test/preface_laws/category.ml
+++ b/test/preface_laws/category.ml
@@ -4,14 +4,12 @@ module type LAWS = sig
   include Semigroupoid.LAWS
 
   val right_identity : string * (('a, 'b) t -> ('a, 'b) t pair)
-
   val left_identity : string * (('a, 'b) t -> ('a, 'b) t pair)
 end
 
 module Laws (C : Preface_specs.CATEGORY) = struct
   include Semigroupoid.Laws (C)
 
-  let right_identity = ("f % id = f", (fun f -> (C.(f % id), f)))
-
-  let left_identity = ("id % f = f", (fun f -> (C.(id % f), f)))
+  let right_identity = ("f % id = f", fun f -> (C.(f % id), f))
+  let left_identity = ("id % f = f", fun f -> (C.(id % f), f))
 end

--- a/test/preface_laws/category.mli
+++ b/test/preface_laws/category.mli
@@ -6,7 +6,6 @@ module type LAWS = sig
   include Semigroupoid.LAWS
 
   val right_identity : string * (('a, 'b) t -> ('a, 'b) t pair)
-
   val left_identity : string * (('a, 'b) t -> ('a, 'b) t pair)
 end
 

--- a/test/preface_laws/choice.ml
+++ b/test/preface_laws/choice.ml
@@ -11,7 +11,6 @@ module type LAWS = sig
     string * (('a, 'b) t -> (('c, 'a) Either.t, ('c, 'b) Either.t) t pair)
 
   val map_snd_left : string * (('a, 'b) t -> ('a, ('b, 'c) Either.t) t pair)
-
   val map_snd_right : string * (('a, 'b) t -> ('a, ('c, 'b) Either.t) t pair)
 
   val contramap_fst_right :
@@ -57,13 +56,13 @@ module Laws (C : Preface_specs.CHOICE) = struct
   let left_defined_by_right =
     let lhs x = C.left x in
     let rhs x = C.dimap Either.swap Either.swap (C.right x) in
-    ("left = dimap Either.swap Either.swap % right", (fun x -> (lhs x, rhs x)))
+    ("left = dimap Either.swap Either.swap % right", fun x -> (lhs x, rhs x))
   ;;
 
   let right_defined_by_left =
     let lhs x = C.right x in
     let rhs x = C.dimap Either.swap Either.swap (C.left x) in
-    ("right = dimap Either.swap Either.swap % left", (fun x -> (lhs x, rhs x)))
+    ("right = dimap Either.swap Either.swap % left", fun x -> (lhs x, rhs x))
   ;;
 
   let map_snd_left =
@@ -71,7 +70,7 @@ module Laws (C : Preface_specs.CHOICE) = struct
     let lhs x = C.map_snd Either.left x in
     let rhs x = (C.contramap_fst Either.left % C.left) x in
     ( "map_snd Either.left = contramap_fst Either.left % left"
-    , (fun x -> (lhs x, rhs x)) )
+    , fun x -> (lhs x, rhs x) )
   ;;
 
   let map_snd_right =
@@ -79,7 +78,7 @@ module Laws (C : Preface_specs.CHOICE) = struct
     let lhs x = C.map_snd Either.right x in
     let rhs x = (C.contramap_fst Either.right % C.right) x in
     ( "map_snd Either.right = contramap_fst Either.right % right"
-    , (fun x -> (lhs x, rhs x)) )
+    , fun x -> (lhs x, rhs x) )
   ;;
 
   let contramap_fst_right =
@@ -89,7 +88,7 @@ module Laws (C : Preface_specs.CHOICE) = struct
     let rhs f x = (C.map_snd (right f) % C.left) x in
     ( "contramap_fst (Fun.Choice.right f) % left = map_snd (Fun.Choice.right \
        f) % left"
-    , (fun f x -> (lhs f x, rhs f x)) )
+    , fun f x -> (lhs f x, rhs f x) )
   ;;
 
   let contramap_fst_left =
@@ -99,20 +98,20 @@ module Laws (C : Preface_specs.CHOICE) = struct
     let rhs f x = (C.map_snd (left f) % C.right) x in
     ( "contramap_fst (Fun.Choice.left f) % right = map_snd (Fun.Choice.left f) \
        % right"
-    , (fun f x -> (lhs f x, rhs f x)) )
+    , fun f x -> (lhs f x, rhs f x) )
   ;;
 
   let left_left =
     let open Preface_core.Fun.Infix in
     let lhs x = (C.left % C.left) x in
     let rhs x = (C.dimap assoc unassoc % C.left) x in
-    ("left % left = dimap assoc unassoc % left", (fun x -> (lhs x, rhs x)))
+    ("left % left = dimap assoc unassoc % left", fun x -> (lhs x, rhs x))
   ;;
 
   let right_right =
     let open Preface_core.Fun.Infix in
     let lhs x = (C.right % C.right) x in
     let rhs x = (C.dimap unassoc assoc % C.right) x in
-    ("left % left = dimap unassoc assoc % right", (fun x -> (lhs x, rhs x)))
+    ("left % left = dimap unassoc assoc % right", fun x -> (lhs x, rhs x))
   ;;
 end

--- a/test/preface_laws/choice.mli
+++ b/test/preface_laws/choice.mli
@@ -11,7 +11,6 @@ module type LAWS = sig
     string * (('a, 'b) t -> (('c, 'a) Either.t, ('c, 'b) Either.t) t pair)
 
   val map_snd_left : string * (('a, 'b) t -> ('a, ('b, 'c) Either.t) t pair)
-
   val map_snd_right : string * (('a, 'b) t -> ('a, ('c, 'b) Either.t) t pair)
 
   val contramap_fst_right :

--- a/test/preface_laws/closed.ml
+++ b/test/preface_laws/closed.ml
@@ -21,7 +21,7 @@ module Laws (C : Preface_specs.CLOSED) = struct
     let rhs f x = (C.map_snd (fun x -> x % f) % C.closed) x in
     ( "contramap_fst (fun x -> x % f) % closed = map_snd (fun x -> x % f) % \
        closed"
-    , (fun f x -> (lhs f x, rhs f x)) )
+    , fun f x -> (lhs f x, rhs f x) )
   ;;
 
   let closed_closed =
@@ -29,13 +29,13 @@ module Laws (C : Preface_specs.CLOSED) = struct
     let rhs x =
       (C.dimap (fun f (x, y) -> f x y) (fun f x y -> f (x, y)) % C.closed) x
     in
-    ("closed % closed = dimap uncurry curry % closed", (fun x -> (lhs x, rhs x)))
+    ("closed % closed = dimap uncurry curry % closed", fun x -> (lhs x, rhs x))
   ;;
 
   let dimap_const =
     let f g = g () in
     let lhs x = (C.dimap Fun.const f % C.closed) x in
     let rhs x = Fun.id x in
-    ("dimap const (fun f -> f ()) % closed = id", (fun x -> (lhs x, rhs x)))
+    ("dimap const (fun f -> f ()) % closed = id", fun x -> (lhs x, rhs x))
   ;;
 end

--- a/test/preface_laws/comonad.ml
+++ b/test/preface_laws/comonad.ml
@@ -6,17 +6,13 @@ module Preserve_identity
     (X : Model.T0) =
 Make.Test (struct
   let name = "extend extract = id"
-
   let arbitrary = A.arbitrary X.arbitrary
 
   type input = X.t F.t
-
   type output = X.t F.t
 
   let equal = A.equal X.equal
-
   let left x = F.(extend extract) x
-
   let right x = Fun.id x
 end)
 
@@ -36,7 +32,6 @@ Make.Test (struct
   ;;
 
   type input = (X.t F.t -> Y.t) QCheck.fun_ * X.t F.t
-
   type output = Y.t
 
   let equal = Y.equal
@@ -108,7 +103,6 @@ Make.Test (struct
   ;;
 
   type input = (X.t F.t -> Y.t) QCheck.fun_ * X.t F.t
-
   type output = Y.t
 
   let equal = Y.equal
@@ -140,7 +134,6 @@ Make.Test (struct
   ;;
 
   type input = (X.t F.t -> Y.t) QCheck.fun_ * X.t F.t
-
   type output = Y.t
 
   let equal = Y.equal
@@ -206,17 +199,13 @@ module Duplicate_preserve_identity
     (X : Model.T0) =
 Make.Test (struct
   let name = "extract % duplicate = id"
-
   let arbitrary = A.arbitrary X.arbitrary
 
   type input = X.t F.t
-
   type output = X.t F.t
 
   let equal = A.equal X.equal
-
   let left x = Preface_stdlib.Fun.Infix.(F.(extract % duplicate) x)
-
   let right x = Fun.id x
 end)
 
@@ -226,17 +215,13 @@ module Map_duplicate_preserve_identity
     (X : Model.T0) =
 Make.Test (struct
   let name = "map extract % duplicate = id"
-
   let arbitrary = A.arbitrary X.arbitrary
 
   type input = X.t F.t
-
   type output = X.t F.t
 
   let equal = A.equal X.equal
-
   let left x = Preface_stdlib.Fun.Infix.(F.(map extract % duplicate) x)
-
   let right x = Fun.id x
 end)
 
@@ -246,17 +231,13 @@ module Map_duplicate_duplicate
     (X : Model.T0) =
 Make.Test (struct
   let name = "duplicate % duplicate = map duplicate % duplicate"
-
   let arbitrary = A.arbitrary X.arbitrary
 
   type input = X.t F.t
-
   type output = X.t F.t F.t F.t
 
   let equal = A.equal (A.equal (A.equal X.equal))
-
   let left x = Preface_stdlib.Fun.Infix.(F.(duplicate % duplicate) x)
-
   let right x = Preface_stdlib.Fun.Infix.(F.(map duplicate % duplicate) x)
 end)
 
@@ -276,7 +257,6 @@ Make.Test (struct
   ;;
 
   type input = (X.t F.t -> Y.t) QCheck.fun_ * X.t F.t
-
   type output = Y.t F.t
 
   let equal = A.equal Y.equal
@@ -298,17 +278,13 @@ module Duplicate_extend_id
     (X : Model.T0) =
 Make.Test (struct
   let name = "duplicate = extend id"
-
   let arbitrary = A.arbitrary X.arbitrary
 
   type input = X.t F.t
-
   type output = X.t F.t F.t
 
   let equal = A.equal (A.equal X.equal)
-
   let left x = F.duplicate x
-
   let right x = (F.extend Fun.id) x
 end)
 
@@ -325,7 +301,6 @@ Make.Test (struct
   ;;
 
   type input = (X.t -> Y.t) QCheck.fun_ * X.t F.t
-
   type output = Y.t F.t
 
   let equal = A.equal Y.equal
@@ -352,11 +327,15 @@ struct
   module Extend_extend = Extend_extend (F) (A) (T.A) (T.B) (T.C)
   module Infix_extract_extend = Infix_extract_extend (F) (A) (T.A) (T.B)
   module Rev_infix_extract_extend = Rev_infix_extract_extend (F) (A) (T.A) (T.B)
+
   module Infix_extend_triple =
     Infix_extend_triple (F) (A) (T.A) (T.B) (T.C) (T.D)
+
   module Duplicate_preserve_identity = Duplicate_preserve_identity (F) (A) (T.A)
+
   module Map_duplicate_preserve_identity =
     Map_duplicate_preserve_identity (F) (A) (T.A)
+
   module Map_duplicate_duplicate = Map_duplicate_duplicate (F) (A) (T.A)
   module Extend_map_duplicate = Extend_map_duplicate (F) (A) (T.A) (T.B)
   module Duplicate_extend_id = Duplicate_extend_id (F) (A) (T.A)

--- a/test/preface_laws/continuation.ml
+++ b/test/preface_laws/continuation.ml
@@ -2,7 +2,6 @@ module Req = struct
   type 'a t = 'a Preface_stdlib.Continuation.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.continuation x
-
   let observable x = Preface_qcheck.Observable.continuation x
 
   let equal f x y =
@@ -13,9 +12,11 @@ end
 module Functor =
   Preface_laws.Functor.Cases (Preface_stdlib.Continuation.Functor) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases (Preface_stdlib.Continuation.Applicative) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases (Preface_stdlib.Continuation.Monad) (Req)
     (Preface_qcheck.Sample.Pack1)

--- a/test/preface_laws/contravariant.ml
+++ b/test/preface_laws/contravariant.ml
@@ -8,15 +8,11 @@ Preface_qcheck.Make.Test (struct
   let name = "map id = id"
 
   type input = X.t F.t
-
   type output = input
 
   let arbitrary = A.arbitrary X.arbitrary
-
   let equal = A.equal X.equal
-
   let left x = F.contramap (fun x -> x) x
-
   let right x = (fun x -> x) x
 end)
 
@@ -30,7 +26,6 @@ Preface_qcheck.Make.Test (struct
   let name = "contramap (f % g) = contramap g % contramap f"
 
   type input = X.t F.t * (Y.t -> Z.t) QCheck.fun_ * (Z.t -> X.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary =

--- a/test/preface_laws/either.ml
+++ b/test/preface_laws/either.ml
@@ -2,9 +2,7 @@ module Req = struct
   type ('a, 'b) t = ('a, 'b) Preface_stdlib.Either.t
 
   let arbitrary x y = Preface_qcheck.Arbitrary.either x y
-
   let observable x y = Preface_qcheck.Observable.either x y
-
   let equal left right = Preface_stdlib.Either.equal left right
 end
 
@@ -12,9 +10,7 @@ module Req_with_int = struct
   type 'a t = (int, 'a) Preface_stdlib.Either.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.either QCheck.int x
-
   let observable x = Preface_qcheck.Observable.either QCheck.Observable.int x
-
   let equal f = Preface_stdlib.Either.equal Int.equal f
 end
 
@@ -22,18 +18,22 @@ module Functor =
   Preface_laws.Functor.Cases
     (Preface_stdlib.Either.Functor (Int)) (Req_with_int)
     (Preface_qcheck.Sample.Pack1)
+
 module Alt =
   Preface_laws.Alt.Semigroup_cases
     (Preface_stdlib.Either.Alt (Int)) (Req_with_int)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases
     (Preface_stdlib.Either.Applicative (Int)) (Req_with_int)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases
     (Preface_stdlib.Either.Monad (Int)) (Req_with_int)
     (Preface_qcheck.Sample.Pack1)
+
 module Bifunctor =
   Preface_laws.Bifunctor.Cases (Preface_stdlib.Either.Bifunctor) (Req)
     (Preface_qcheck.Sample.Pack1)

--- a/test/preface_laws/fun.ml
+++ b/test/preface_laws/fun.ml
@@ -1,9 +1,12 @@
 module Category = Preface_laws.Category.Laws (Preface_stdlib.Fun.Category)
 module Arrow = Preface_laws.Arrow.Laws (Preface_stdlib.Fun.Arrow)
+
 module Arrow_choice =
   Preface_laws.Arrow_choice.Laws (Preface_stdlib.Fun.Arrow_choice)
+
 module Arrow_apply =
   Preface_laws.Arrow_apply.Laws (Preface_stdlib.Fun.Arrow_apply)
+
 module Profunctor = Preface_laws.Profunctor.Laws (Preface_stdlib.Fun.Profunctor)
 module Strong = Preface_laws.Strong.Laws (Preface_stdlib.Fun.Strong)
 module Choice = Preface_laws.Choice.Laws (Preface_stdlib.Fun.Choice)
@@ -11,38 +14,36 @@ module Closed = Preface_laws.Closed.Laws (Preface_stdlib.Fun.Closed)
 module Either = Preface_stdlib.Either
 
 let tuple_eq f g (a, b) (a', b') = f a a' && g b b'
-
 let either_eq left right = Preface_core.Shims.Either.equal ~left ~right
-
 let either l r = Preface_qcheck.Arbitrary.either l r
 
 let pro_dimap_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Profunctor.dimap_identity in
+  let name, test = Profunctor.dimap_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let pro_fst_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Profunctor.contramap_fst_identity in
+  let name, test = Profunctor.contramap_fst_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let pro_snd_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Profunctor.map_snd_identity in
+  let name, test = Profunctor.map_snd_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -55,12 +56,12 @@ let pro_dimap_eq (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       P.A.arbitrary
   in
-  let (name, test) = Profunctor.dimap_equality in
+  let name, test = Profunctor.dimap_equality in
   Test.make ~name ~count arbitrary (fun (f', g', pro', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply pro' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.D.equal (left value) (right value) )
 ;;
 
@@ -77,14 +78,14 @@ let pro_dimap_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.F.arbitrary)
       P.C.arbitrary
   in
-  let (name, test) = Profunctor.dimap_parametricity in
+  let name, test = Profunctor.dimap_parametricity in
   Test.make ~name ~count arbitrary (fun ((f', g'), (h', i'), pro', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let h = Fn.apply h' in
       let i = Fn.apply i' in
       let p = Fn.apply pro' in
-      let (left, right) = test f g h i p in
+      let left, right = test f g h i p in
       P.E.equal (left value) (right value) )
 ;;
 
@@ -97,12 +98,12 @@ let pro_fst_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.D.arbitrary)
       P.C.arbitrary
   in
-  let (name, test) = Profunctor.contramap_fst_parametricity in
+  let name, test = Profunctor.contramap_fst_parametricity in
   Test.make ~name ~count arbitrary (fun (f', g', pro', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply pro' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.D.equal (left value) (right value) )
 ;;
 
@@ -115,42 +116,42 @@ let pro_snd_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.D.observable P.C.arbitrary)
       P.D.arbitrary
   in
-  let (name, test) = Profunctor.map_snd_parametricity in
+  let name, test = Profunctor.map_snd_parametricity in
   Test.make ~name ~count arbitrary (fun (f', g', pro', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply pro' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.B.equal (left value) (right value) )
 ;;
 
 let strong_dimap_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Strong.dimap_identity in
+  let name, test = Strong.dimap_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let strong_fst_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Strong.contramap_fst_identity in
+  let name, test = Strong.contramap_fst_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let strong_snd_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Strong.map_snd_identity in
+  let name, test = Strong.map_snd_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -163,12 +164,12 @@ let strong_dimap_eq (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       P.A.arbitrary
   in
-  let (name, test) = Strong.dimap_equality in
+  let name, test = Strong.dimap_equality in
   Test.make ~name ~count arbitrary (fun (f', g', strong', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply strong' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.D.equal (left value) (right value) )
 ;;
 
@@ -185,14 +186,14 @@ let strong_dimap_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.F.arbitrary)
       P.C.arbitrary
   in
-  let (name, test) = Strong.dimap_parametricity in
+  let name, test = Strong.dimap_parametricity in
   Test.make ~name ~count arbitrary (fun ((f', g'), (h', i'), strong', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let h = Fn.apply h' in
       let i = Fn.apply i' in
       let p = Fn.apply strong' in
-      let (left, right) = test f g h i p in
+      let left, right = test f g h i p in
       P.E.equal (left value) (right value) )
 ;;
 
@@ -205,12 +206,12 @@ let strong_fst_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.D.arbitrary)
       P.C.arbitrary
   in
-  let (name, test) = Strong.contramap_fst_parametricity in
+  let name, test = Strong.contramap_fst_parametricity in
   Test.make ~name ~count arbitrary (fun (f', g', strong', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply strong' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.D.equal (left value) (right value) )
 ;;
 
@@ -223,12 +224,12 @@ let strong_snd_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.D.observable P.C.arbitrary)
       P.D.arbitrary
   in
-  let (name, test) = Strong.map_snd_parametricity in
+  let name, test = Strong.map_snd_parametricity in
   Test.make ~name ~count arbitrary (fun (f', g', strong', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply strong' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -237,10 +238,10 @@ let strong_fst_define_snd (module P : Preface_qcheck.Sample.PACKAGE) count =
   let arbitrary =
     pair (fun1 P.A.observable P.B.arbitrary) (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Strong.fst_define_snd in
+  let name, test = Strong.fst_define_snd in
   Test.make ~name ~count arbitrary (fun (strong', value) ->
       let p = Fn.apply strong' in
-      let (left, right) = test p in
+      let left, right = test p in
       tuple_eq P.B.equal P.C.equal (left value) (right value) )
 ;;
 
@@ -249,10 +250,10 @@ let strong_snd_define_fst (module P : Preface_qcheck.Sample.PACKAGE) count =
   let arbitrary =
     pair (fun1 P.A.observable P.B.arbitrary) (pair P.C.arbitrary P.A.arbitrary)
   in
-  let (name, test) = Strong.snd_define_fst in
+  let name, test = Strong.snd_define_fst in
   Test.make ~name ~count arbitrary (fun (strong', value) ->
       let p = Fn.apply strong' in
-      let (left, right) = test p in
+      let left, right = test p in
       tuple_eq P.C.equal P.B.equal (left value) (right value) )
 ;;
 
@@ -261,10 +262,10 @@ let strong_contramap_fst (module P : Preface_qcheck.Sample.PACKAGE) count =
   let arbitrary =
     pair (fun1 P.A.observable P.B.arbitrary) (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Strong.contramap_fst in
+  let name, test = Strong.contramap_fst in
   Test.make ~name ~count arbitrary (fun (strong', value) ->
       let p = Fn.apply strong' in
-      let (left, right) = test p in
+      let left, right = test p in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -273,10 +274,10 @@ let strong_contramap_snd (module P : Preface_qcheck.Sample.PACKAGE) count =
   let arbitrary =
     pair (fun1 P.A.observable P.B.arbitrary) (pair P.C.arbitrary P.A.arbitrary)
   in
-  let (name, test) = Strong.contramap_snd in
+  let name, test = Strong.contramap_snd in
   Test.make ~name ~count arbitrary (fun (strong', value) ->
       let p = Fn.apply strong' in
-      let (left, right) = test p in
+      let left, right = test p in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -288,11 +289,11 @@ let strong_dinaturality_fst (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.C.observable P.D.arbitrary)
       (pair P.C.arbitrary P.A.arbitrary)
   in
-  let (name, test) = Strong.dinaturality_fst in
+  let name, test = Strong.dinaturality_fst in
   Test.make ~name ~count arbitrary (fun (f', strong', value) ->
       let f = Fn.apply f' in
       let p = Fn.apply strong' in
-      let (left, right) = test f p in
+      let left, right = test f p in
       tuple_eq P.D.equal P.B.equal (left value) (right value) )
 ;;
 
@@ -304,11 +305,11 @@ let strong_dinaturality_snd (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.C.observable P.D.arbitrary)
       (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Strong.dinaturality_snd in
+  let name, test = Strong.dinaturality_snd in
   Test.make ~name ~count arbitrary (fun (f', strong', value) ->
       let f = Fn.apply f' in
       let p = Fn.apply strong' in
-      let (left, right) = test f p in
+      let left, right = test f p in
       tuple_eq P.B.equal P.D.equal (left value) (right value) )
 ;;
 
@@ -319,10 +320,10 @@ let strong_fst_fst_is_dimap (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.A.observable P.B.arbitrary)
       (pair (pair P.A.arbitrary P.C.arbitrary) P.D.arbitrary)
   in
-  let (name, test) = Strong.fst_fst_is_dmap in
+  let name, test = Strong.fst_fst_is_dmap in
   Test.make ~name ~count arbitrary (fun (strong', value) ->
       let p = Fn.apply strong' in
-      let (left, right) = test p in
+      let left, right = test p in
       tuple_eq
         (tuple_eq P.B.equal P.C.equal)
         P.D.equal (left value) (right value) )
@@ -338,10 +339,10 @@ let strong_snd_snd_is_dimap (module P : Preface_qcheck.Sample.PACKAGE) count =
       (pair P.E.arbitrary
          (pair P.F.arbitrary (pair P.A.arbitrary P.B.arbitrary)) )
   in
-  let (name, test) = Strong.snd_snd_is_dmap in
+  let name, test = Strong.snd_snd_is_dmap in
   Test.make ~name ~count arbitrary (fun (strong', value) ->
       let p = Fn.apply strong' in
-      let (left, right) = test p in
+      let left, right = test p in
       tuple_eq P.E.equal
         (tuple_eq P.F.equal (tuple_eq P.C.equal P.D.equal))
         (left value) (right value) )
@@ -350,30 +351,30 @@ let strong_snd_snd_is_dimap (module P : Preface_qcheck.Sample.PACKAGE) count =
 let choice_dimap_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Choice.dimap_identity in
+  let name, test = Choice.dimap_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let choice_fst_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Choice.contramap_fst_identity in
+  let name, test = Choice.contramap_fst_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let choice_snd_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Choice.map_snd_identity in
+  let name, test = Choice.map_snd_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -386,12 +387,12 @@ let choice_dimap_eq (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       P.A.arbitrary
   in
-  let (name, test) = Choice.dimap_equality in
+  let name, test = Choice.dimap_equality in
   Test.make ~name ~count arbitrary (fun (f', g', choice', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply choice' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.D.equal (left value) (right value) )
 ;;
 
@@ -408,14 +409,14 @@ let choice_dimap_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.F.arbitrary)
       P.C.arbitrary
   in
-  let (name, test) = Choice.dimap_parametricity in
+  let name, test = Choice.dimap_parametricity in
   Test.make ~name ~count arbitrary (fun ((f', g'), (h', i'), choice', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let h = Fn.apply h' in
       let i = Fn.apply i' in
       let p = Fn.apply choice' in
-      let (left, right) = test f g h i p in
+      let left, right = test f g h i p in
       P.E.equal (left value) (right value) )
 ;;
 
@@ -428,12 +429,12 @@ let choice_fst_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.D.arbitrary)
       P.C.arbitrary
   in
-  let (name, test) = Choice.contramap_fst_parametricity in
+  let name, test = Choice.contramap_fst_parametricity in
   Test.make ~name ~count arbitrary (fun (f', g', choice', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply choice' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.D.equal (left value) (right value) )
 ;;
 
@@ -446,12 +447,12 @@ let choice_snd_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.D.observable P.C.arbitrary)
       P.D.arbitrary
   in
-  let (name, test) = Choice.map_snd_parametricity in
+  let name, test = Choice.map_snd_parametricity in
   Test.make ~name ~count arbitrary (fun (f', g', choice', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply choice' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -463,10 +464,10 @@ let choice_left_defined_by_right (module P : Preface_qcheck.Sample.PACKAGE)
       (fun1 P.A.observable P.B.arbitrary)
       (either P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Choice.left_defined_by_right in
+  let name, test = Choice.left_defined_by_right in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       either_eq P.B.equal P.C.equal (left value) (right value) )
 ;;
 
@@ -478,30 +479,30 @@ let choice_right_defined_by_left (module P : Preface_qcheck.Sample.PACKAGE)
       (fun1 P.A.observable P.B.arbitrary)
       (either P.C.arbitrary P.A.arbitrary)
   in
-  let (name, test) = Choice.right_defined_by_left in
+  let name, test = Choice.right_defined_by_left in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       either_eq P.C.equal P.B.equal (left value) (right value) )
 ;;
 
 let choice_map_snd_left (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Choice.map_snd_left in
+  let name, test = Choice.map_snd_left in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       either_eq P.B.equal P.C.equal (left value) (right value) )
 ;;
 
 let choice_map_snd_right (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Choice.map_snd_right in
+  let name, test = Choice.map_snd_right in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       either_eq P.C.equal P.B.equal (left value) (right value) )
 ;;
 
@@ -513,11 +514,11 @@ let choice_contramp_fst_right (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.C.observable P.D.arbitrary)
       (either P.C.arbitrary P.A.arbitrary)
   in
-  let (name, test) = Choice.contramap_fst_right in
+  let name, test = Choice.contramap_fst_right in
   Test.make ~name ~count arbitrary (fun (f', c', value) ->
       let f = Fn.apply f' in
       let c = Fn.apply c' in
-      let (left, right) = test f c in
+      let left, right = test f c in
       either_eq P.D.equal P.B.equal (left value) (right value) )
 ;;
 
@@ -529,11 +530,11 @@ let choice_contramp_fst_left (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.C.observable P.D.arbitrary)
       (either P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Choice.contramap_fst_left in
+  let name, test = Choice.contramap_fst_left in
   Test.make ~name ~count arbitrary (fun (f', c', value) ->
       let f = Fn.apply f' in
       let c = Fn.apply c' in
-      let (left, right) = test f c in
+      let left, right = test f c in
       either_eq P.B.equal P.D.equal (left value) (right value) )
 ;;
 
@@ -544,10 +545,10 @@ let choice_left_left (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.A.observable P.B.arbitrary)
       (either (either P.A.arbitrary P.C.arbitrary) P.D.arbitrary)
   in
-  let (name, test) = Choice.left_left in
+  let name, test = Choice.left_left in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       either_eq
         (either_eq P.B.equal P.C.equal)
         P.D.equal (left value) (right value) )
@@ -560,10 +561,10 @@ let choice_right_right (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.A.observable P.B.arbitrary)
       (either P.C.arbitrary (either P.D.arbitrary P.A.arbitrary))
   in
-  let (name, test) = Choice.right_right in
+  let name, test = Choice.right_right in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       either_eq P.C.equal
         (either_eq P.D.equal P.B.equal)
         (left value) (right value) )
@@ -572,30 +573,30 @@ let choice_right_right (module P : Preface_qcheck.Sample.PACKAGE) count =
 let closed_dimap_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Closed.dimap_identity in
+  let name, test = Closed.dimap_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let closed_fst_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Closed.contramap_fst_identity in
+  let name, test = Closed.contramap_fst_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let closed_snd_id (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Closed.map_snd_identity in
+  let name, test = Closed.map_snd_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -608,12 +609,12 @@ let closed_dimap_eq (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       P.A.arbitrary
   in
-  let (name, test) = Closed.dimap_equality in
+  let name, test = Closed.dimap_equality in
   Test.make ~name ~count arbitrary (fun (f', g', pro', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply pro' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.D.equal (left value) (right value) )
 ;;
 
@@ -630,14 +631,14 @@ let closed_dimap_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.F.arbitrary)
       P.C.arbitrary
   in
-  let (name, test) = Closed.dimap_parametricity in
+  let name, test = Closed.dimap_parametricity in
   Test.make ~name ~count arbitrary (fun ((f', g'), (h', i'), pro', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let h = Fn.apply h' in
       let i = Fn.apply i' in
       let p = Fn.apply pro' in
-      let (left, right) = test f g h i p in
+      let left, right = test f g h i p in
       P.E.equal (left value) (right value) )
 ;;
 
@@ -650,12 +651,12 @@ let closed_fst_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.D.arbitrary)
       P.C.arbitrary
   in
-  let (name, test) = Closed.contramap_fst_parametricity in
+  let name, test = Closed.contramap_fst_parametricity in
   Test.make ~name ~count arbitrary (fun (f', g', pro', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply pro' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.D.equal (left value) (right value) )
 ;;
 
@@ -668,12 +669,12 @@ let closed_snd_param (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.D.observable P.C.arbitrary)
       P.D.arbitrary
   in
-  let (name, test) = Closed.map_snd_parametricity in
+  let name, test = Closed.map_snd_parametricity in
   Test.make ~name ~count arbitrary (fun (f', g', pro', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply pro' in
-      let (left, right) = test f g p in
+      let left, right = test f g p in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -687,12 +688,12 @@ let closed_contramap_fst_closed (module P : Preface_qcheck.Sample.PACKAGE) count
       (fun1 P.B.observable P.C.arbitrary)
       P.A.arbitrary
   in
-  let (name, test) = Closed.contramap_fst_closed in
+  let name, test = Closed.contramap_fst_closed in
   Test.make ~name ~count arbitrary (fun (f', pro', g', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let p = Fn.apply pro' in
-      let (left, right) = test f p in
+      let left, right = test f p in
       P.D.equal (left g value) (right g value) )
 ;;
 
@@ -705,11 +706,11 @@ let closed_closed (module P : Preface_qcheck.Sample.PACKAGE) count =
       (pair P.C.arbitrary P.D.arbitrary)
   in
 
-  let (name, test) = Closed.closed_closed in
+  let name, test = Closed.closed_closed in
   Test.make ~name ~count arbitrary (fun (p', f', (a, b)) ->
       let f = Fn.apply f' in
       let p = Fn.apply p' in
-      let (left, right) = test p in
+      let left, right = test p in
       P.B.equal (left f a b) (right f a b) )
 ;;
 
@@ -717,30 +718,30 @@ let closed_dimap_const (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
 
-  let (name, test) = Closed.dimap_const in
+  let name, test = Closed.dimap_const in
   Test.make ~name ~count arbitrary (fun (p', value) ->
       let p = Fn.apply p' in
-      let (left, right) = test p in
+      let left, right = test p in
       P.B.equal (left value) (right value) )
 ;;
 
 let cat_right_identity (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Category.right_identity in
+  let name, test = Category.right_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let cat_left_identity (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Category.left_identity in
+  let name, test = Category.left_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -753,32 +754,32 @@ let cat_associativity (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.D.observable P.C.arbitrary)
       P.D.arbitrary
   in
-  let (name, test) = Category.associativity in
+  let name, test = Category.associativity in
   Test.make ~name ~count arbitrary (fun (f', g', h', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let h = Fn.apply h' in
-      let (left, right) = test f g h in
+      let left, right = test f g h in
       P.B.equal (left value) (right value) )
 ;;
 
 let arrow_right_identity (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Arrow.right_identity in
+  let name, test = Arrow.right_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let arrow_left_identity (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Arrow.left_identity in
+  let name, test = Arrow.left_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -791,21 +792,21 @@ let arrow_associativity (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.D.observable P.C.arbitrary)
       P.D.arbitrary
   in
-  let (name, test) = Arrow.associativity in
+  let name, test = Arrow.associativity in
   Test.make ~name ~count arbitrary (fun (f', g', h', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let h = Fn.apply h' in
-      let (left, right) = test f g h in
+      let left, right = test f g h in
       P.B.equal (left value) (right value) )
 ;;
 
 let arrow_law1 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = P.A.arbitrary in
-  let (name, test) = Arrow.law1 in
+  let name, test = Arrow.law1 in
   Test.make ~name ~count arbitrary (fun value ->
-      let (left, right) = test () in
+      let left, right = test () in
       P.A.equal (left value) (right value) )
 ;;
 
@@ -817,11 +818,11 @@ let arrow_law2 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       P.A.arbitrary
   in
-  let (name, test) = Arrow.law2 in
+  let name, test = Arrow.law2 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
-      let (left, right) = test f g in
+      let left, right = test f g in
       P.C.equal (left value) (right value) )
 ;;
 
@@ -830,10 +831,10 @@ let arrow_law3 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let arbitrary =
     pair (fun1 P.A.observable P.B.arbitrary) (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow.law3 in
+  let name, test = Arrow.law3 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       tuple_eq P.B.equal P.C.equal (left value) (right value) )
 ;;
 
@@ -845,11 +846,11 @@ let arrow_law4 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       (pair P.A.arbitrary P.D.arbitrary)
   in
-  let (name, test) = Arrow.law4 in
+  let name, test = Arrow.law4 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
-      let (left, right) = test f g in
+      let left, right = test f g in
       tuple_eq P.C.equal P.D.equal (left value) (right value) )
 ;;
 
@@ -861,11 +862,11 @@ let arrow_law5 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.C.observable P.D.arbitrary)
       (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow.law5 in
+  let name, test = Arrow.law5 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
-      let (left, right) = test f g in
+      let left, right = test f g in
       tuple_eq P.B.equal P.D.equal (left value) (right value) )
 ;;
 
@@ -874,10 +875,10 @@ let arrow_law6 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let arbitrary =
     pair (fun1 P.A.observable P.B.arbitrary) (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow.law6 in
+  let name, test = Arrow.law6 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -888,10 +889,10 @@ let arrow_law7 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.A.observable P.B.arbitrary)
       (pair (pair P.A.arbitrary P.C.arbitrary) P.D.arbitrary)
   in
-  let (name, test) = Arrow.law7 in
+  let name, test = Arrow.law7 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Preface_stdlib.Fun.Arrow.arrow (Fn.apply f') in
-      let (left, right) = test f in
+      let left, right = test f in
       tuple_eq P.B.equal
         (tuple_eq P.C.equal P.D.equal)
         (left value) (right value) )
@@ -901,10 +902,10 @@ let arrow_choice_right_identity (module P : Preface_qcheck.Sample.PACKAGE) count
     =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Arrow_choice.right_identity in
+  let name, test = Arrow_choice.right_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -912,10 +913,10 @@ let arrow_choice_left_identity (module P : Preface_qcheck.Sample.PACKAGE) count
     =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Arrow_choice.left_identity in
+  let name, test = Arrow_choice.left_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -929,21 +930,21 @@ let arrow_choice_associativity (module P : Preface_qcheck.Sample.PACKAGE) count
       (fun1 P.D.observable P.C.arbitrary)
       P.D.arbitrary
   in
-  let (name, test) = Arrow_choice.associativity in
+  let name, test = Arrow_choice.associativity in
   Test.make ~name ~count arbitrary (fun (f', g', h', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let h = Fn.apply h' in
-      let (left, right) = test f g h in
+      let left, right = test f g h in
       P.B.equal (left value) (right value) )
 ;;
 
 let arrow_choice_law1 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = P.A.arbitrary in
-  let (name, test) = Arrow_choice.law1 in
+  let name, test = Arrow_choice.law1 in
   Test.make ~name ~count arbitrary (fun value ->
-      let (left, right) = test () in
+      let left, right = test () in
       P.A.equal (left value) (right value) )
 ;;
 
@@ -955,11 +956,11 @@ let arrow_choice_law2 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       P.A.arbitrary
   in
-  let (name, test) = Arrow_choice.law2 in
+  let name, test = Arrow_choice.law2 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
-      let (left, right) = test f g in
+      let left, right = test f g in
       P.C.equal (left value) (right value) )
 ;;
 
@@ -968,10 +969,10 @@ let arrow_choice_law3 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let arbitrary =
     pair (fun1 P.A.observable P.B.arbitrary) (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow_choice.law3 in
+  let name, test = Arrow_choice.law3 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       tuple_eq P.B.equal P.C.equal (left value) (right value) )
 ;;
 
@@ -983,11 +984,11 @@ let arrow_choice_law4 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       (pair P.A.arbitrary P.D.arbitrary)
   in
-  let (name, test) = Arrow_choice.law4 in
+  let name, test = Arrow_choice.law4 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
-      let (left, right) = test f g in
+      let left, right = test f g in
       tuple_eq P.C.equal P.D.equal (left value) (right value) )
 ;;
 
@@ -999,11 +1000,11 @@ let arrow_choice_law5 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.C.observable P.D.arbitrary)
       (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow_choice.law5 in
+  let name, test = Arrow_choice.law5 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
-      let (left, right) = test f g in
+      let left, right = test f g in
       tuple_eq P.B.equal P.D.equal (left value) (right value) )
 ;;
 
@@ -1012,10 +1013,10 @@ let arrow_choice_law6 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let arbitrary =
     pair (fun1 P.A.observable P.B.arbitrary) (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow_choice.law6 in
+  let name, test = Arrow_choice.law6 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -1026,10 +1027,10 @@ let arrow_choice_law7 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.A.observable P.B.arbitrary)
       (pair (pair P.A.arbitrary P.C.arbitrary) P.D.arbitrary)
   in
-  let (name, test) = Arrow_choice.law7 in
+  let name, test = Arrow_choice.law7 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Preface_stdlib.Fun.Arrow_choice.arrow (Fn.apply f') in
-      let (left, right) = test f in
+      let left, right = test f in
       tuple_eq P.B.equal
         (tuple_eq P.C.equal P.D.equal)
         (left value) (right value) )
@@ -1042,10 +1043,10 @@ let arrow_choice_law8 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.A.observable P.B.arbitrary)
       (either P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow_choice.law8 in
+  let name, test = Arrow_choice.law8 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       either_eq P.B.equal P.C.equal (left value) (right value) )
 ;;
 
@@ -1057,21 +1058,21 @@ let arrow_choice_law9 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       (either P.A.arbitrary P.D.arbitrary)
   in
-  let (name, test) = Arrow_choice.law9 in
+  let name, test = Arrow_choice.law9 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Preface_stdlib.Fun.Arrow_choice.arrow (Fn.apply f') in
       let g = Preface_stdlib.Fun.Arrow_choice.arrow (Fn.apply g') in
-      let (left, right) = test f g in
+      let left, right = test f g in
       either_eq P.C.equal P.D.equal (left value) (right value) )
 ;;
 
 let arrow_choice_law10 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Arrow_choice.law10 in
+  let name, test = Arrow_choice.law10 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Preface_stdlib.Fun.Arrow_choice.arrow (Fn.apply f') in
-      let (left, right) = test f in
+      let left, right = test f in
       either_eq P.B.equal P.C.equal (left value) (right value) )
 ;;
 
@@ -1083,11 +1084,11 @@ let arrow_choice_law11 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.C.observable P.D.arbitrary)
       (either P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow_choice.law11 in
+  let name, test = Arrow_choice.law11 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Preface_stdlib.Fun.Arrow_choice.arrow (Fn.apply f') in
       let g = Fn.apply g' in
-      let (left, right) = test f g in
+      let left, right = test f g in
       either_eq P.B.equal P.D.equal (left value) (right value) )
 ;;
 
@@ -1098,10 +1099,10 @@ let arrow_choice_law12 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.A.observable P.B.arbitrary)
       (either (either P.A.arbitrary P.C.arbitrary) P.D.arbitrary)
   in
-  let (name, test) = Arrow_choice.law12 in
+  let name, test = Arrow_choice.law12 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Preface_stdlib.Fun.Arrow_choice.arrow (Fn.apply f') in
-      let (left, right) = test f in
+      let left, right = test f in
       either_eq P.B.equal
         (either_eq P.C.equal P.D.equal)
         (left value) (right value) )
@@ -1111,20 +1112,20 @@ let arrow_apply_right_identity (module P : Preface_qcheck.Sample.PACKAGE) count
     =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Arrow_apply.right_identity in
+  let name, test = Arrow_apply.right_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
 let arrow_apply_left_identity (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair (fun1 P.A.observable P.B.arbitrary) P.A.arbitrary in
-  let (name, test) = Arrow_apply.left_identity in
+  let name, test = Arrow_apply.left_identity in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -1137,21 +1138,21 @@ let arrow_apply_associativity (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.D.observable P.C.arbitrary)
       P.D.arbitrary
   in
-  let (name, test) = Arrow_apply.associativity in
+  let name, test = Arrow_apply.associativity in
   Test.make ~name ~count arbitrary (fun (f', g', h', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
       let h = Fn.apply h' in
-      let (left, right) = test f g h in
+      let left, right = test f g h in
       P.B.equal (left value) (right value) )
 ;;
 
 let arrow_apply_law1 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = P.A.arbitrary in
-  let (name, test) = Arrow_apply.law1 in
+  let name, test = Arrow_apply.law1 in
   Test.make ~name ~count arbitrary (fun value ->
-      let (left, right) = test () in
+      let left, right = test () in
       P.A.equal (left value) (right value) )
 ;;
 
@@ -1163,11 +1164,11 @@ let arrow_apply_law2 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       P.A.arbitrary
   in
-  let (name, test) = Arrow_apply.law2 in
+  let name, test = Arrow_apply.law2 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
-      let (left, right) = test f g in
+      let left, right = test f g in
       P.C.equal (left value) (right value) )
 ;;
 
@@ -1176,10 +1177,10 @@ let arrow_apply_law3 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let arbitrary =
     pair (fun1 P.A.observable P.B.arbitrary) (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow_apply.law3 in
+  let name, test = Arrow_apply.law3 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       tuple_eq P.B.equal P.C.equal (left value) (right value) )
 ;;
 
@@ -1191,11 +1192,11 @@ let arrow_apply_law4 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.B.observable P.C.arbitrary)
       (pair P.A.arbitrary P.D.arbitrary)
   in
-  let (name, test) = Arrow_apply.law4 in
+  let name, test = Arrow_apply.law4 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
-      let (left, right) = test f g in
+      let left, right = test f g in
       tuple_eq P.C.equal P.D.equal (left value) (right value) )
 ;;
 
@@ -1207,11 +1208,11 @@ let arrow_apply_law5 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.C.observable P.D.arbitrary)
       (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow_apply.law5 in
+  let name, test = Arrow_apply.law5 in
   Test.make ~name ~count arbitrary (fun (f', g', value) ->
       let f = Fn.apply f' in
       let g = Fn.apply g' in
-      let (left, right) = test f g in
+      let left, right = test f g in
       tuple_eq P.B.equal P.D.equal (left value) (right value) )
 ;;
 
@@ -1220,10 +1221,10 @@ let arrow_apply_law6 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let arbitrary =
     pair (fun1 P.A.observable P.B.arbitrary) (pair P.A.arbitrary P.C.arbitrary)
   in
-  let (name, test) = Arrow_apply.law6 in
+  let name, test = Arrow_apply.law6 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Fn.apply f' in
-      let (left, right) = test f in
+      let left, right = test f in
       P.B.equal (left value) (right value) )
 ;;
 
@@ -1234,10 +1235,10 @@ let arrow_apply_law7 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.A.observable P.B.arbitrary)
       (pair (pair P.A.arbitrary P.C.arbitrary) P.D.arbitrary)
   in
-  let (name, test) = Arrow_apply.law7 in
+  let name, test = Arrow_apply.law7 in
   Test.make ~name ~count arbitrary (fun (f', value) ->
       let f = Preface_stdlib.Fun.Arrow_apply.arrow (Fn.apply f') in
-      let (left, right) = test f in
+      let left, right = test f in
       tuple_eq P.B.equal
         (tuple_eq P.C.equal P.D.equal)
         (left value) (right value) )
@@ -1246,9 +1247,9 @@ let arrow_apply_law7 (module P : Preface_qcheck.Sample.PACKAGE) count =
 let arrow_apply_law8 (module P : Preface_qcheck.Sample.PACKAGE) count =
   let open QCheck in
   let arbitrary = pair P.A.arbitrary P.B.arbitrary in
-  let (name, test) = Arrow_apply.law8 in
+  let name, test = Arrow_apply.law8 in
   Test.make ~name ~count arbitrary (fun value ->
-      let (left, right) = test () in
+      let left, right = test () in
       tuple_eq P.A.equal P.B.equal (left value) (right value) )
 ;;
 
@@ -1259,11 +1260,11 @@ let arrow_apply_law9 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.A.observable P.B.arbitrary)
       (pair (fun1 P.B.observable P.C.arbitrary) P.A.arbitrary)
   in
-  let (name, test) = Arrow_apply.law9 in
+  let name, test = Arrow_apply.law9 in
   Test.make ~name ~count arbitrary (fun (f', (g', value)) ->
       let f = Preface_stdlib.Fun.Arrow_apply.arrow (Fn.apply f') in
       let g = Preface_stdlib.Fun.Arrow_apply.arrow (Fn.apply g') in
-      let (left, right) = test f in
+      let left, right = test f in
       let l = left (g, value) in
       let r = right (g, value) in
       P.C.equal l r )
@@ -1276,11 +1277,11 @@ let arrow_apply_law10 (module P : Preface_qcheck.Sample.PACKAGE) count =
       (fun1 P.A.observable P.B.arbitrary)
       (pair (fun1 P.C.observable P.A.arbitrary) P.C.arbitrary)
   in
-  let (name, test) = Arrow_apply.law10 in
+  let name, test = Arrow_apply.law10 in
   Test.make ~name ~count arbitrary (fun (f', (g', value)) ->
       let f = Preface_stdlib.Fun.Arrow_apply.arrow (Fn.apply f') in
       let g = Preface_stdlib.Fun.Arrow_apply.arrow (Fn.apply g') in
-      let (left, right) = test f in
+      let left, right = test f in
       let l = left (g, value) in
       let r = right (g, value) in
       P.B.equal l r )
@@ -1306,14 +1307,17 @@ module Functor =
   Preface_laws.Functor.Cases
     (Preface_make.Functor.From_arrow (Preface_stdlib.Fun.Arrow)) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases
     (Preface_make.Applicative.From_arrow (Preface_stdlib.Fun.Arrow)) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases
     (Preface_make.Monad.From_arrow_apply (Preface_stdlib.Fun.Arrow_apply)) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Selective =
   Preface_laws.Selective.Cases
     (Preface_make.Selective.From_arrow_choice

--- a/test/preface_laws/functor.ml
+++ b/test/preface_laws/functor.ml
@@ -8,15 +8,11 @@ Preface_qcheck.Make.Test (struct
   let name = "map id = id"
 
   type input = X.t F.t
-
   type output = input
 
   let arbitrary = A.arbitrary X.arbitrary
-
   let equal = A.equal X.equal
-
   let left x = F.map (fun x -> x) x
-
   let right x = (fun x -> x) x
 end)
 
@@ -30,7 +26,6 @@ Preface_qcheck.Make.Test (struct
   let name = "map (f % g) = map f % map g"
 
   type input = X.t F.t * (Y.t -> Z.t) QCheck.fun_ * (X.t -> Y.t) QCheck.fun_
-
   type output = Z.t F.t
 
   let arbitrary =

--- a/test/preface_laws/identity.ml
+++ b/test/preface_laws/identity.ml
@@ -2,24 +2,26 @@ module Req = struct
   type 'a t = 'a Preface_stdlib.Identity.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.identity x
-
   let observable x = Preface_qcheck.Observable.identity x
-
   let equal x = Preface_stdlib.Identity.equal x
 end
 
 module Functor =
   Preface_laws.Functor.Cases (Preface_stdlib.Identity.Functor) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases (Preface_stdlib.Identity.Applicative) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Selective =
   Preface_laws.Selective.Rigid_cases (Preface_stdlib.Identity.Selective) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases (Preface_stdlib.Identity.Monad) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Comonad =
   Preface_laws.Comonad.Cases (Preface_stdlib.Identity.Comonad) (Req)
     (Preface_qcheck.Sample.Pack1)

--- a/test/preface_laws/list.ml
+++ b/test/preface_laws/list.ml
@@ -2,27 +2,30 @@ module Req = struct
   type 'a t = 'a Preface_stdlib.List.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.small_list x
-
   let observable x = Preface_qcheck.Observable.list x
-
   let equal x = Preface_stdlib.List.equal x
 end
 
 module Functor =
   Preface_laws.Functor.Cases (Preface_stdlib.List.Functor) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases (Preface_stdlib.List.Applicative) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Selective =
   Preface_laws.Selective.Rigid_cases (Preface_stdlib.List.Selective) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Alternative =
   Preface_laws.Alternative.Cases (Preface_stdlib.List.Alternative) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases (Preface_stdlib.List.Monad) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad_plus_monoidal =
   Preface_laws.Monad_plus.Cases_for_monoidal
     (Preface_stdlib.List.Monad_plus)

--- a/test/preface_laws/misc.ml
+++ b/test/preface_laws/misc.ml
@@ -2,9 +2,7 @@ module Int_req = struct
   type t = int
 
   let arbitrary = QCheck.int
-
   let observable = QCheck.Observable.int
-
   let equal = Int.equal
 end
 
@@ -12,9 +10,7 @@ module String_req = struct
   type t = string
 
   let arbitrary = QCheck.string
-
   let observable = QCheck.Observable.string
-
   let equal = String.equal
 end
 
@@ -65,12 +61,16 @@ module String_monoid =
 
 module Sum_semigroup_cases =
   Preface_laws.Semigroup.Cases (Sum_semigroup) (Int_req)
+
 module Prod_semigroup_cases =
   Preface_laws.Semigroup.Cases (Prod_semigroup) (Int_req)
+
 module String_semigroup_cases =
   Preface_laws.Semigroup.Cases (String_semigroup) (String_req)
+
 module Sum_monoid_cases = Preface_laws.Monoid.Cases (Sum_monoid) (Int_req)
 module Prod_monoid_cases = Preface_laws.Monoid.Cases (Prod_monoid) (Int_req)
+
 module String_monoid_cases =
   Preface_laws.Monoid.Cases (String_monoid) (String_req)
 

--- a/test/preface_laws/monad.ml
+++ b/test/preface_laws/monad.ml
@@ -8,11 +8,9 @@ Preface_qcheck.Make.Test (struct
   let name = "join % join = join % map join"
 
   type input = X.t F.t F.t F.t
-
   type output = X.t F.t
 
   let arbitrary = A.arbitrary (A.arbitrary (A.arbitrary X.arbitrary))
-
   let equal = A.equal X.equal
 
   let left x =
@@ -34,7 +32,6 @@ Preface_qcheck.Make.Test (struct
   let name = "join % map return = join % return = id"
 
   type input = X.t F.t
-
   type output = X.t F.t * X.t F.t
 
   let arbitrary = A.arbitrary X.arbitrary
@@ -60,11 +57,9 @@ Preface_qcheck.Make.Test (struct
   let name = "map id = id"
 
   type input = X.t F.t
-
   type output = X.t F.t
 
   let arbitrary = A.arbitrary X.arbitrary
-
   let equal = A.equal X.equal
 
   let left x =
@@ -85,7 +80,6 @@ Preface_qcheck.Make.Test (struct
   let name = "map (f % g) = map f % map g"
 
   type input = X.t F.t * (Z.t -> Y.t) QCheck.fun_ * (X.t -> Z.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -121,7 +115,6 @@ Preface_qcheck.Make.Test (struct
   let name = "map f % join = join % map (map f)"
 
   type input = X.t F.t F.t * (X.t -> Y.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -153,11 +146,9 @@ Preface_qcheck.Make.Test (struct
   let name = "map f % return = return f"
 
   type input = X.t * (X.t -> Y.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary = QCheck.(pair X.arbitrary (fun1 X.observable Y.arbitrary))
-
   let equal = A.equal Y.equal
 
   let left (x, f') =
@@ -182,7 +173,6 @@ Preface_qcheck.Make.Test (struct
   let name = "return x >>= f = f x"
 
   type input = X.t * (X.t -> Y.t F.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -210,15 +200,11 @@ Preface_qcheck.Make.Test (struct
   let name = "x >>= return = x"
 
   type input = X.t F.t
-
   type output = X.t F.t
 
   let arbitrary = A.arbitrary X.arbitrary
-
   let equal = A.equal X.equal
-
   let left x = F.(x >>= return)
-
   let right x = x
 end)
 
@@ -254,7 +240,7 @@ Preface_qcheck.Make.Test (struct
   let right (x, f', g') =
     let f = QCheck.Fn.apply f'
     and g = QCheck.Fn.apply g' in
-    F.(x >>= (fun y -> f y >>= g))
+    F.(x >>= fun y -> f y >>= g)
   ;;
 end)
 
@@ -267,7 +253,6 @@ Preface_qcheck.Make.Test (struct
   let name = "return >=> f = f"
 
   type input = X.t * (X.t -> Y.t F.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -296,7 +281,6 @@ Preface_qcheck.Make.Test (struct
   let name = "f >=> return = f"
 
   type input = X.t * (X.t -> Y.t F.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -367,8 +351,10 @@ struct
   module Join_map_1 = Join_map_1 (F) (A) (T.A)
   module Join_map_2 = Join_map_2 (F) (A) (T.A)
   module Natural_transformation_1 = Natural_transformation_1 (F) (A) (T.A)
+
   module Natural_transformation_2 =
     Natural_transformation_2 (F) (A) (T.A) (T.B) (T.C)
+
   module Natural_transformation_3 = Natural_transformation_3 (F) (A) (T.A) (T.B)
   module Natural_transformation_4 = Natural_transformation_4 (F) (A) (T.A) (T.B)
   module Left_identity = Left_identity (F) (A) (T.A) (T.B)
@@ -376,6 +362,7 @@ struct
   module Associativity = Associativity (F) (A) (T.A) (T.B) (T.C)
   module Kleisli_left_identity = Kleisli_left_identity (F) (A) (T.A) (T.B)
   module Kleisli_right_identity = Kleisli_right_identity (F) (A) (T.A) (T.B)
+
   module Kleisli_associativity =
     Kleisli_associativity (F) (A) (T.A) (T.B) (T.C) (T.D)
 

--- a/test/preface_laws/monad_plus.ml
+++ b/test/preface_laws/monad_plus.ml
@@ -9,11 +9,9 @@ Preface_qcheck.Make.Test (struct
   let name = "neutral >>= x = neutral"
 
   type input = (X.t -> Y.t F.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary = QCheck.fun1 X.observable (A.arbitrary Y.arbitrary)
-
   let equal = A.equal Y.equal
 
   let left f' =
@@ -33,7 +31,6 @@ Preface_qcheck.Make.Test (struct
   let name = "(a <|> b) >>= f = (a >>= f) <|> (b >>= f)"
 
   type input = X.t F.t * X.t F.t * (X.t -> Y.t F.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -63,15 +60,11 @@ Preface_qcheck.Make.Test (struct
   let name = "(return a) <|> b = return a"
 
   type input = X.t * X.t F.t
-
   type output = X.t F.t
 
   let arbitrary = QCheck.(pair X.arbitrary (A.arbitrary X.arbitrary))
-
   let equal = A.equal X.equal
-
   let left (a, b) = F.(return a <|> b)
-
   let right (a, _) = F.return a
 end)
 
@@ -85,9 +78,7 @@ module Monoidal_behaviour
          type t = X.t F.t
 
          let equal = A.equal X.equal
-
          let arbitrary = A.arbitrary X.arbitrary
-
          let observable = A.observable X.observable
        end)
 

--- a/test/preface_laws/monoid.ml
+++ b/test/preface_laws/monoid.ml
@@ -5,15 +5,11 @@ Preface_qcheck.Make.Test (struct
   let name = "neutral <|> x = x"
 
   type input = F.t
-
   type output = F.t
 
   let arbitrary = A.arbitrary
-
   let equal = A.equal
-
   let left x = F.(neutral <|> x)
-
   let right x = x
 end)
 
@@ -24,15 +20,11 @@ Preface_qcheck.Make.Test (struct
   let name = "x <|> neutral = x"
 
   type input = F.t
-
   type output = F.t
 
   let arbitrary = A.arbitrary
-
   let equal = A.equal
-
   let left x = F.(x <|> neutral)
-
   let right x = x
 end)
 

--- a/test/preface_laws/nonempty_list.ml
+++ b/test/preface_laws/nonempty_list.ml
@@ -2,31 +2,34 @@ module Req = struct
   type 'a t = 'a Preface_stdlib.Nonempty_list.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.nonempty_list x
-
   let observable x = Preface_qcheck.Observable.nonempty_list x
-
   let equal = Preface_stdlib.Nonempty_list.equal
 end
 
 module Functor =
   Preface_laws.Functor.Cases (Preface_stdlib.Nonempty_list.Functor) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases
     (Preface_stdlib.Nonempty_list.Applicative)
     (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Selective =
   Preface_laws.Selective.Rigid_cases
     (Preface_stdlib.Nonempty_list.Selective)
     (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases (Preface_stdlib.Nonempty_list.Monad) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Alt =
   Preface_laws.Alt.Semigroup_cases (Preface_stdlib.Nonempty_list.Alt) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Comonad =
   Preface_laws.Comonad.Cases (Preface_stdlib.Nonempty_list.Comonad) (Req)
     (Preface_qcheck.Sample.Pack1)

--- a/test/preface_laws/option.ml
+++ b/test/preface_laws/option.ml
@@ -2,21 +2,22 @@ module Req = struct
   type 'a t = 'a Preface_stdlib.Option.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.option x
-
   let observable x = Preface_qcheck.Observable.option x
-
   let equal x = Preface_stdlib.Option.equal x
 end
 
 module Functor =
   Preface_laws.Functor.Cases (Preface_stdlib.Option.Functor) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases (Preface_stdlib.Option.Applicative) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases (Preface_stdlib.Option.Monad) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Alternative =
   Preface_laws.Alternative.Cases (Preface_stdlib.Option.Alternative) (Req)
     (Preface_qcheck.Sample.Pack1)

--- a/test/preface_laws/pair.ml
+++ b/test/preface_laws/pair.ml
@@ -2,9 +2,7 @@ module Req = struct
   type ('a, 'b) t = ('a, 'b) Preface_stdlib.Pair.t
 
   let arbitrary x y = Preface_qcheck.Arbitrary.pair x y
-
   let observable x y = Preface_qcheck.Observable.pair x y
-
   let equal x y = Preface_stdlib.Pair.equal x y
 end
 

--- a/test/preface_laws/profunctor.ml
+++ b/test/preface_laws/profunctor.ml
@@ -4,9 +4,7 @@ module type LAWS = sig
   type ('a, 'b) t
 
   val dimap_identity : string * (('a, 'b) t -> ('a, 'b) t pair)
-
   val contramap_fst_identity : string * (('a, 'b) t -> ('a, 'b) t pair)
-
   val map_snd_identity : string * (('a, 'b) t -> ('a, 'b) t pair)
 
   val dimap_equality :
@@ -34,19 +32,19 @@ module Laws (P : Preface_specs.PROFUNCTOR) = struct
   let dimap_identity =
     let lhs x = P.dimap Fun.id Fun.id x in
     let rhs x = Fun.id x in
-    ("dimap id id = id", (fun x -> (lhs x, rhs x)))
+    ("dimap id id = id", fun x -> (lhs x, rhs x))
   ;;
 
   let contramap_fst_identity =
     let lhs x = P.contramap_fst Fun.id x in
     let rhs x = Fun.id x in
-    ("contramap_fst id = id", (fun x -> (lhs x, rhs x)))
+    ("contramap_fst id = id", fun x -> (lhs x, rhs x))
   ;;
 
   let map_snd_identity =
     let lhs x = P.map_snd Fun.id x in
     let rhs x = Fun.id x in
-    ("map_snd id = id", (fun x -> (lhs x, rhs x)))
+    ("map_snd id = id", fun x -> (lhs x, rhs x))
   ;;
 
   let dimap_equality =
@@ -54,7 +52,7 @@ module Laws (P : Preface_specs.PROFUNCTOR) = struct
     let lhs f g x = P.dimap f g x in
     let rhs f g x = (P.contramap_fst f % P.map_snd g) x in
     ( "dimap f g = contramap_fst f % map_snd g"
-    , (fun f g x -> (lhs f g x, rhs f g x)) )
+    , fun f g x -> (lhs f g x, rhs f g x) )
   ;;
 
   let dimap_parametricity =
@@ -62,7 +60,7 @@ module Laws (P : Preface_specs.PROFUNCTOR) = struct
     let lhs f g h i x = P.dimap (f % g) (h % i) x in
     let rhs f g h i x = (P.dimap g h % P.dimap f i) x in
     ( "dimap (f % g) (h % i) = dimap g h % dimap f i"
-    , (fun f g h i x -> (lhs f g h i x, rhs f g h i x)) )
+    , fun f g h i x -> (lhs f g h i x, rhs f g h i x) )
   ;;
 
   let contramap_fst_parametricity =
@@ -70,7 +68,7 @@ module Laws (P : Preface_specs.PROFUNCTOR) = struct
     let lhs f g x = P.contramap_fst (f % g) x in
     let rhs f g x = (P.contramap_fst g % P.contramap_fst f) x in
     ( "contramap_fst (f % g) = contramap_fst g % contramap_fst f"
-    , (fun f g x -> (lhs f g x, rhs f g x)) )
+    , fun f g x -> (lhs f g x, rhs f g x) )
   ;;
 
   let map_snd_parametricity =
@@ -78,6 +76,6 @@ module Laws (P : Preface_specs.PROFUNCTOR) = struct
     let lhs f g x = P.map_snd (f % g) x in
     let rhs f g x = (P.map_snd f % P.map_snd g) x in
     ( "map_snd (f % g) = map_snd f % map_snd g"
-    , (fun f g x -> (lhs f g x, rhs f g x)) )
+    , fun f g x -> (lhs f g x, rhs f g x) )
   ;;
 end

--- a/test/preface_laws/profunctor.mli
+++ b/test/preface_laws/profunctor.mli
@@ -6,9 +6,7 @@ module type LAWS = sig
   type ('a, 'b) t
 
   val dimap_identity : string * (('a, 'b) t -> ('a, 'b) t pair)
-
   val contramap_fst_identity : string * (('a, 'b) t -> ('a, 'b) t pair)
-
   val map_snd_identity : string * (('a, 'b) t -> ('a, 'b) t pair)
 
   val dimap_equality :

--- a/test/preface_laws/result.ml
+++ b/test/preface_laws/result.ml
@@ -2,9 +2,7 @@ module Req = struct
   type ('a, 'b) t = ('a, 'b) Preface_stdlib.Result.t
 
   let arbitrary x y = Preface_qcheck.Arbitrary.result x y
-
   let observable x y = Preface_qcheck.Observable.result x y
-
   let equal x y = Preface_stdlib.Result.equal x y
 end
 
@@ -12,9 +10,7 @@ module Req_with_int = struct
   type 'a t = ('a, int) Preface_stdlib.Result.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.result x QCheck.int
-
   let observable x = Preface_qcheck.Observable.result x QCheck.Observable.int
-
   let equal f = Preface_stdlib.Result.equal f Int.equal
 end
 
@@ -22,18 +18,22 @@ module Functor =
   Preface_laws.Functor.Cases
     (Preface_stdlib.Result.Functor (Int)) (Req_with_int)
     (Preface_qcheck.Sample.Pack1)
+
 module Alt =
   Preface_laws.Alt.Semigroup_cases
     (Preface_stdlib.Result.Alt (Int)) (Req_with_int)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases
     (Preface_stdlib.Result.Applicative (Int)) (Req_with_int)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases
     (Preface_stdlib.Result.Monad (Int)) (Req_with_int)
     (Preface_qcheck.Sample.Pack1)
+
 module Bifunctor =
   Preface_laws.Bifunctor.Cases (Preface_stdlib.Result.Bifunctor) (Req)
     (Preface_qcheck.Sample.Pack1)

--- a/test/preface_laws/selective.ml
+++ b/test/preface_laws/selective.ml
@@ -12,15 +12,11 @@ Preface_qcheck.Make.Test (struct
   let name = "x <*? pure id = Either.case id id <$> x"
 
   type input = (X.t, X.t) Either.t F.t
-
   type output = X.t F.t
 
   let arbitrary = A.arbitrary (either X.arbitrary X.arbitrary)
-
   let equal = A.equal X.equal
-
   let left x = F.(x <*? pure (fun x -> x))
-
   let right x = F.(Either.case (fun x -> x) (fun x -> x) <$> x)
 end)
 
@@ -236,7 +232,6 @@ Preface_qcheck.Make.Test (struct
   let name = "(x <*? pure y) = (Either.case y id <$> x)"
 
   type input = (X.t, Y.t) Either.t F.t * (X.t -> Y.t) QCheck.fun_
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -269,7 +264,6 @@ Preface_qcheck.Make.Test (struct
   let name = "(pure (Right x) <*? y) = pure x"
 
   type input = X.t * (Y.t -> X.t) QCheck.fun_ F.t
-
   type output = X.t F.t
 
   let arbitrary =
@@ -295,7 +289,6 @@ Preface_qcheck.Make.Test (struct
   let name = "(pure (Left x) <*? y) = ((|>) x) <$> y"
 
   type input = X.t * (X.t -> Y.t) QCheck.fun_ F.t
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -324,7 +317,6 @@ Preface_qcheck.Make.Test (struct
   let name = "f <*> g = apply f g"
 
   type input = (X.t -> Y.t) QCheck.fun_ F.t * X.t F.t
-
   type output = Y.t F.t
 
   let arbitrary =
@@ -355,7 +347,6 @@ Preface_qcheck.Make.Test (struct
   let name = "(x *> (y <*? z)) = ((x *> y) <*? z)"
 
   type input = X.t F.t * (Y.t, Z.t) Either.t F.t * (Y.t -> Z.t) QCheck.fun_ F.t
-
   type output = Z.t F.t
 
   let arbitrary =

--- a/test/preface_laws/semigroup.ml
+++ b/test/preface_laws/semigroup.ml
@@ -7,15 +7,11 @@ Preface_qcheck.Make.Test (struct
   let name = "combine is associative"
 
   type input = F.t * F.t * F.t
-
   type output = F.t
 
   let arbitrary = QCheck.triple A.arbitrary A.arbitrary A.arbitrary
-
   let equal = A.equal
-
   let left (a, b, c) = F.(combine (combine a b) c)
-
   let right (a, b, c) = F.(combine a (combine b c))
 end)
 

--- a/test/preface_laws/semigroupoid.ml
+++ b/test/preface_laws/semigroupoid.ml
@@ -11,7 +11,6 @@ module Laws (S : Preface_specs.SEMIGROUPOID) = struct
   type ('a, 'b) t = ('a, 'b) S.t
 
   let associativity =
-    ( "f % (g % h) = (f % g) % h"
-    , (fun f g h -> (S.(f % (g % h)), S.(f % g % h))) )
+    ("f % (g % h) = (f % g) % h", fun f g h -> (S.(f % (g % h)), S.(f % g % h)))
   ;;
 end

--- a/test/preface_laws/seq.ml
+++ b/test/preface_laws/seq.ml
@@ -2,27 +2,30 @@ module Req = struct
   type 'a t = 'a Preface_stdlib.Seq.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.seq x
-
   let observable x = Preface_qcheck.Observable.seq x
-
   let equal x = Preface_stdlib.Seq.equal x
 end
 
 module Functor =
   Preface_laws.Functor.Cases (Preface_stdlib.Seq.Functor) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases (Preface_stdlib.Seq.Applicative) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Selective =
   Preface_laws.Selective.Rigid_cases (Preface_stdlib.Seq.Selective) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Alternative =
   Preface_laws.Alternative.Cases (Preface_stdlib.Seq.Alternative) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases (Preface_stdlib.Seq.Monad) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad_plus_monoidal =
   Preface_laws.Monad_plus.Cases_for_monoidal
     (Preface_stdlib.Seq.Monad_plus)

--- a/test/preface_laws/stream.ml
+++ b/test/preface_laws/stream.ml
@@ -2,7 +2,6 @@ module Req = struct
   type 'a t = 'a Preface_stdlib.Stream.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.stream x
-
   let observable x = Preface_qcheck.Observable.stream ~fuel:10 x
 
   let equal f x y =
@@ -15,12 +14,15 @@ end
 module Functor =
   Preface_laws.Functor.Cases (Preface_stdlib.Stream.Functor) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases (Preface_stdlib.Stream.Applicative) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases (Preface_stdlib.Stream.Monad) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Comonad =
   Preface_laws.Comonad.Cases (Preface_stdlib.Stream.Comonad) (Req)
     (Preface_qcheck.Sample.Pack1)

--- a/test/preface_laws/strong.ml
+++ b/test/preface_laws/strong.ml
@@ -5,11 +5,8 @@ module type LAWS = sig
   include Profunctor.LAWS
 
   val fst_define_snd : string * (('a, 'b) t -> ('a * 'c, 'b * 'c) t pair)
-
   val snd_define_fst : string * (('a, 'b) t -> ('c * 'a, 'c * 'b) t pair)
-
   val contramap_fst : string * (('a, 'b) t -> ('a * 'c, 'b) t pair)
-
   val contramap_snd : string * (('a, 'b) t -> ('c * 'a, 'b) t pair)
 
   val dinaturality_fst :
@@ -34,27 +31,27 @@ module Laws (S : Preface_specs.STRONG) = struct
   let fst_define_snd =
     let lhs x = S.fst x in
     let rhs x = S.dimap P.swap P.swap (S.snd x) in
-    ("fst = dimap Pair.swap Pair.swap % snd", (fun x -> (lhs x, rhs x)))
+    ("fst = dimap Pair.swap Pair.swap % snd", fun x -> (lhs x, rhs x))
   ;;
 
   let snd_define_fst =
     let lhs x = S.snd x in
     let rhs x = S.dimap P.swap P.swap (S.fst x) in
-    ("fst = dimap Pair.swap Pair.swap % snd", (fun x -> (lhs x, rhs x)))
+    ("fst = dimap Pair.swap Pair.swap % snd", fun x -> (lhs x, rhs x))
   ;;
 
   let contramap_fst =
     let lhs x = S.contramap_fst P.fst x in
     let rhs x = S.map_snd P.fst (S.fst x) in
     ( "contramap_fst Pair.fst = (map_snd Pair.fst) % fst"
-    , (fun x -> (lhs x, rhs x)) )
+    , fun x -> (lhs x, rhs x) )
   ;;
 
   let contramap_snd =
     let lhs x = S.contramap_fst P.snd x in
     let rhs x = S.map_snd P.snd (S.snd x) in
     ( "contramap_fst Pair.snd = (map_snd Pair.snd) % snd"
-    , (fun x -> (lhs x, rhs x)) )
+    , fun x -> (lhs x, rhs x) )
   ;;
 
   let dinaturality_fst =
@@ -63,7 +60,7 @@ module Laws (S : Preface_specs.STRONG) = struct
     let lhs f = S.contramap_fst (snd f) % S.fst in
     let rhs f = S.map_snd (snd f) % S.fst in
     ( "contramap_fst (Fun.Strong.snd f) % fst = map_snd (Fun.Strong.snd f) % fst"
-    , (fun f x -> (lhs f x, rhs f x)) )
+    , fun f x -> (lhs f x, rhs f x) )
   ;;
 
   let dinaturality_snd =
@@ -72,11 +69,10 @@ module Laws (S : Preface_specs.STRONG) = struct
     let lhs f = S.contramap_fst (fst f) % S.snd in
     let rhs f = S.map_snd (fst f) % S.snd in
     ( "contramap_fst (Fun.Strong.fst f) % snd = map_snd (Fun.Strong.fst f) % snd"
-    , (fun f x -> (lhs f x, rhs f x)) )
+    , fun f x -> (lhs f x, rhs f x) )
   ;;
 
   let assoc ((a, b), c) = (a, (b, c))
-
   let unassoc (a, (b, c)) = ((a, b), c)
 
   let fst_fst_is_dmap =
@@ -85,7 +81,7 @@ module Laws (S : Preface_specs.STRONG) = struct
     let rhs x = (S.dimap assoc unassoc % S.fst) x in
     ( "fst % fst = dimap (fun ((a, b), c) ->  (a, (b, c))) (fun (a, (b, c)) -> \
        ((a, b), c)) % fst"
-    , (fun x -> (lhs x, rhs x)) )
+    , fun x -> (lhs x, rhs x) )
   ;;
 
   let snd_snd_is_dmap =
@@ -94,6 +90,6 @@ module Laws (S : Preface_specs.STRONG) = struct
     let rhs x = (S.dimap unassoc assoc % S.snd) x in
     ( "snd % snd = dimap (fun ((a, b), c) ->  (a, (b, c))) (fun (a, (b, c)) -> \
        ((a, b), c)) % snd"
-    , (fun x -> (lhs x, rhs x)) )
+    , fun x -> (lhs x, rhs x) )
   ;;
 end

--- a/test/preface_laws/strong.mli
+++ b/test/preface_laws/strong.mli
@@ -4,11 +4,8 @@ module type LAWS = sig
   include Profunctor.LAWS
 
   val fst_define_snd : string * (('a, 'b) t -> ('a * 'c, 'b * 'c) t pair)
-
   val snd_define_fst : string * (('a, 'b) t -> ('c * 'a, 'c * 'b) t pair)
-
   val contramap_fst : string * (('a, 'b) t -> ('a * 'c, 'b) t pair)
-
   val contramap_snd : string * (('a, 'b) t -> ('c * 'a, 'b) t pair)
 
   val dinaturality_fst :

--- a/test/preface_laws/try.ml
+++ b/test/preface_laws/try.ml
@@ -2,21 +2,22 @@ module Req = struct
   type 'a t = 'a Preface_stdlib.Try.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.try_ x
-
   let observable x = Preface_qcheck.Observable.try_ x
-
   let equal x = Preface_stdlib.Try.equal x
 end
 
 module Functor =
   Preface_laws.Functor.Cases (Preface_stdlib.Try.Functor) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Alt =
   Preface_laws.Alt.Semigroup_cases (Preface_stdlib.Try.Alt) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases (Preface_stdlib.Try.Applicative) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases (Preface_stdlib.Try.Monad) (Req)
     (Preface_qcheck.Sample.Pack1)

--- a/test/preface_laws/validate.ml
+++ b/test/preface_laws/validate.ml
@@ -2,24 +2,26 @@ module Req = struct
   type 'a t = 'a Preface_stdlib.Validate.t
 
   let arbitrary x = Preface_qcheck.Arbitrary.validate x
-
   let observable x = Preface_qcheck.Observable.validate x
-
   let equal x y = Preface_stdlib.Validate.equal x y
 end
 
 module Functor =
   Preface_laws.Functor.Cases (Preface_stdlib.Validate.Functor) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Alt =
   Preface_laws.Alt.Semigroup_cases (Preface_stdlib.Validate.Alt) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases (Preface_stdlib.Validate.Applicative) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases (Preface_stdlib.Validate.Monad) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Selective =
   Preface_laws.Selective.Cases (Preface_stdlib.Validate.Selective) (Req)
     (Preface_qcheck.Sample.Pack1)

--- a/test/preface_laws/validation.ml
+++ b/test/preface_laws/validation.ml
@@ -6,9 +6,7 @@ module Req = struct
   type ('a, 'b) t = ('a, 'b) Preface_stdlib.Validation.t
 
   let arbitrary x y = Preface_qcheck.Arbitrary.validation x y
-
   let observable x y = Preface_qcheck.Observable.validation x y
-
   let equal x y = Preface_stdlib.Validation.equal x y
 end
 
@@ -35,21 +33,26 @@ module Functor =
   Preface_laws.Functor.Cases
     (Preface_stdlib.Validation.Functor (Error)) (Req_with_exn)
     (Preface_qcheck.Sample.Pack1)
+
 module Alt =
   Preface_laws.Alt.Semigroup_cases
     (Preface_stdlib.Validation.Alt (Error)) (Req_with_exn)
     (Preface_qcheck.Sample.Pack1)
+
 module Applicative =
   Preface_laws.Applicative.Cases
     (Preface_stdlib.Validation.Applicative (Error)) (Req_with_exn)
     (Preface_qcheck.Sample.Pack1)
+
 module Monad =
   Preface_laws.Monad.Cases
     (Preface_stdlib.Validation.Monad (Error)) (Req_with_exn)
     (Preface_qcheck.Sample.Pack1)
+
 module Bifunctor =
   Preface_laws.Bifunctor.Cases (Preface_stdlib.Validation.Bifunctor) (Req)
     (Preface_qcheck.Sample.Pack1)
+
 module Selective =
   Preface_laws.Selective.Cases
     (Preface_stdlib.Validation.Selective (Error)) (Req_with_exn)

--- a/test/preface_qcheck/arbitrary.ml
+++ b/test/preface_qcheck/arbitrary.ml
@@ -23,7 +23,7 @@ let identity ?collect arbitrary =
   let small =
     let open Opt in
     arbitrary.QCheck.small
-    >|= (fun f x -> x |> Preface_stdlib.Identity.extract |> f)
+    >|= fun f x -> x |> Preface_stdlib.Identity.extract |> f
   in
   QCheck.make ?print ?shrink ?small ?collect gen
 ;;

--- a/test/preface_qcheck/arbitrary.mli
+++ b/test/preface_qcheck/arbitrary.mli
@@ -82,81 +82,42 @@ val state : 'a t -> ('b -> 'a * 'b) t
 (** {2 QCheck's arbitraries} *)
 
 val unit : unit t
-
 val bool : bool t
-
 val float : float t
-
 val pos_float : float t
-
 val neg_float : float t
-
 val float_bound_inclusive : float -> float t
-
 val float_bound_exclusive : float -> float t
-
 val float_range : float -> float -> float t
-
 val int : int t
-
 val int_bound : int -> int t
-
 val int_range : int -> int -> int t
-
 val small_nat : int t
-
 val small_signed_int : int t
-
 val int32 : int32 t
-
 val int64 : int64 t
-
 val pos_int : int t
-
 val small_int_corners : unit -> int t
-
 val neg_int : int t
-
 val char : char t
-
 val printable_char : char t
-
 val numeral_char : char t
-
 val string_gen_of_size : int Gen.t -> char Gen.t -> string t
-
 val string_gen : char Gen.t -> string t
-
 val string : string t
-
 val small_string : string t
-
 val small_list : 'a t -> 'a list t
-
 val string_of_size : int Gen.t -> string t
-
 val printable_string : string t
-
 val printable_string_of_size : int Gen.t -> string t
-
 val small_printable_string : string t
-
 val numeral_string : string t
-
 val numeral_string_of_size : int Gen.t -> string t
-
 val list : 'a t -> 'a list t
-
 val list_of_size : int Gen.t -> 'a t -> 'a list t
-
 val array : 'a t -> 'a array t
-
 val array_of_size : int Gen.t -> 'a t -> 'a array t
-
 val pair : 'a t -> 'b t -> ('a * 'b) t
-
 val triple : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
-
 val quad : 'a t -> 'b t -> 'c t -> 'd t -> ('a * 'b * 'c * 'd) t
-
 val option : ?ratio:float -> 'a t -> 'a option t

--- a/test/preface_qcheck/exceptions.ml
+++ b/test/preface_qcheck/exceptions.ml
@@ -1,17 +1,10 @@
 (** A collection of exceptions (in order to be generated). *)
 
 exception A
-
 exception B
-
 exception C of int
-
 exception D of float
-
 exception E of string
-
 exception F of int list
-
 exception G of float list
-
 exception H of string list

--- a/test/preface_qcheck/gen.ml
+++ b/test/preface_qcheck/gen.ml
@@ -20,7 +20,6 @@ let nonempty_list_size size gen st =
 ;;
 
 let nonempty_list g s = nonempty_list_size nat g s
-
 let small_nonempty_list g s = nonempty_list_size small_nat g s
 
 let seq_size size gen st =
@@ -29,9 +28,7 @@ let seq_size size gen st =
 ;;
 
 let seq g s = seq_size nat g s
-
 let small_seq g s = seq_size small_nat g s
-
 let continuation f state = Preface_stdlib.Continuation.pure (f state)
 
 let exn state =
@@ -90,5 +87,5 @@ let stream f state =
 
 let state f state =
   let r = f state in
-  (fun s -> (r, s))
+  fun s -> (r, s)
 ;;

--- a/test/preface_qcheck/make.ml
+++ b/test/preface_qcheck/make.ml
@@ -1,16 +1,11 @@
 module type DRIVER = sig
   type input
-
   type output
 
   val arbitrary : input QCheck.arbitrary
-
   val left : input -> output
-
   val right : input -> output
-
   val equal : output -> output -> bool
-
   val name : string
 end
 

--- a/test/preface_qcheck/make.mli
+++ b/test/preface_qcheck/make.mli
@@ -1,17 +1,12 @@
 (** Describes a Test driver. *)
 module type DRIVER = sig
   type input
-
   type output
 
   val arbitrary : input QCheck.arbitrary
-
   val left : input -> output
-
   val right : input -> output
-
   val equal : output -> output -> bool
-
   val name : string
 end
 

--- a/test/preface_qcheck/model.mli
+++ b/test/preface_qcheck/model.mli
@@ -2,9 +2,7 @@ module type T0 = sig
   type t
 
   val arbitrary : t Arbitrary.t
-
   val observable : t Observable.t
-
   val equal : t -> t -> bool
 end
 
@@ -12,9 +10,7 @@ module type T1 = sig
   type 'a t
 
   val arbitrary : 'a QCheck.arbitrary -> 'a t QCheck.arbitrary
-
   val observable : 'a QCheck.Observable.t -> 'a t Observable.t
-
   val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 end
 

--- a/test/preface_qcheck/observable.ml
+++ b/test/preface_qcheck/observable.ml
@@ -45,8 +45,8 @@ let stream ?(fuel = 200) a =
     match
       (Preface_stdlib.Stream.take fuel x, Preface_stdlib.Stream.take fuel y)
     with
-    | (Error _, _) | (_, Error _) -> false
-    | (Ok l, Ok r) -> Preface_stdlib.List.equal (Observable.equal a) l r
+    | Error _, _ | _, Error _ -> false
+    | Ok l, Ok r -> Preface_stdlib.List.equal (Observable.equal a) l r
   in
   let hash x = Hashtbl.hash (Preface_stdlib.Stream.take fuel x) in
   Observable.make ~eq ~hash print

--- a/test/preface_qcheck/observable.mli
+++ b/test/preface_qcheck/observable.mli
@@ -9,23 +9,13 @@ include module type of QCheck.Observable with type 'a t := 'a t
 (** {1 Custom Observable} *)
 
 val identity : 'a t -> 'a Preface_stdlib.Identity.t t
-
 val either : 'a t -> 'b t -> ('a, 'b) Preface_stdlib.Either.t t
-
 val exn : exn t
-
 val result : 'a t -> 'b t -> ('a, 'b) Preface_stdlib.Result.t t
-
 val try_ : 'a t -> 'a Preface_stdlib.Try.t t
-
 val stream : ?fuel:int -> 'a t -> 'a Preface_stdlib.Stream.t t
-
 val continuation : 'a t -> 'a Preface_stdlib.Continuation.t t
-
 val nonempty_list : 'a t -> 'a Preface_stdlib.Nonempty_list.t t
-
 val seq : 'a t -> 'a Preface_stdlib.Seq.t t
-
 val validation : 'a t -> 'b t -> ('a, 'b) Preface_stdlib.Validation.t t
-
 val validate : 'a t -> 'a Preface_stdlib.Validate.t t

--- a/test/preface_qcheck/printer.ml
+++ b/test/preface_qcheck/printer.ml
@@ -25,7 +25,6 @@ let validation pp_left pp_right x =
 ;;
 
 let exn e = Format.asprintf "%a " Preface_stdlib.Exn.pp e
-
 let try_ x = result x exn
 
 let nonempty_list pp x =
@@ -33,7 +32,6 @@ let nonempty_list pp x =
 ;;
 
 let seq pp x = Format.asprintf "%a" (Preface_stdlib.Seq.pp (to_string pp)) x
-
 let validate x = validation x (nonempty_list exn)
 
 let stream pp x =

--- a/test/preface_qcheck/sample.ml
+++ b/test/preface_qcheck/sample.ml
@@ -2,9 +2,7 @@ module Int = struct
   type t = int
 
   let arbitrary = QCheck.int
-
   let observable = QCheck.Observable.int
-
   let equal = Int.equal
 end
 
@@ -12,9 +10,7 @@ module String = struct
   type t = string
 
   let arbitrary = QCheck.small_printable_string
-
   let observable = QCheck.Observable.string
-
   let equal = String.equal
 end
 
@@ -22,25 +18,17 @@ module Float = struct
   type t = float
 
   let arbitrary = QCheck.float
-
   let observable = QCheck.Observable.float
-
   let equal = Float.equal
 end
 
 module type PACKAGE = sig
   module A : Model.T0
-
   module B : Model.T0
-
   module C : Model.T0
-
   module D : Model.T0
-
   module E : Model.T0
-
   module F : Model.T0
-
   module G : Model.T0
 end
 

--- a/test/preface_qcheck/sample.mli
+++ b/test/preface_qcheck/sample.mli
@@ -3,26 +3,18 @@
 (** {2 Presaved generators} *)
 
 module Int : Model.T0 with type t = int
-
 module String : Model.T0 with type t = string
-
 module Float : Model.T0 with type t = float
 
 (** {2 Packaged Samples} *)
 
 module type PACKAGE = sig
   module A : Model.T0
-
   module B : Model.T0
-
   module C : Model.T0
-
   module D : Model.T0
-
   module E : Model.T0
-
   module F : Model.T0
-
   module G : Model.T0
 end
 

--- a/test/preface_stdlib_test/list_test.ml
+++ b/test/preface_stdlib_test/list_test.ml
@@ -3,7 +3,6 @@ let fold_map_over_values () =
     type t = int
 
     let neutral = 1
-
     let combine = ( * )
   end) in
   let expected = 120
@@ -21,7 +20,6 @@ let fold_map_over_empty () =
     type t = int
 
     let neutral = 1
-
     let combine = ( * )
   end) in
   let expected = 1

--- a/test/preface_stdlib_test/option_test.ml
+++ b/test/preface_stdlib_test/option_test.ml
@@ -21,9 +21,7 @@ let map_scenario_2 () =
 ;;
 
 let create age name = (age, name)
-
 let is_positive number = if number >= 0 then Some number else None
-
 let is_potential_name name = if String.length name >= 3 then Some name else None
 
 let parallel_validation_1 () =
@@ -66,7 +64,7 @@ let sequential_validation_1 () =
   let expected = Some (10, "John Doe")
   and computed =
     let open Monad in
-    is_positive 10 >|= create >>= (fun f -> is_potential_name "John Doe" >|= f)
+    is_positive 10 >|= create >>= fun f -> is_potential_name "John Doe" >|= f
   in
   Alcotest.(check (option (pair int string)))
     "Sequential_Validation_1" expected computed
@@ -76,9 +74,7 @@ let sequential_validation_2 () =
   let expected = None
   and computed =
     let open Monad in
-    is_positive (-10)
-    >|= create
-    >>= (fun f -> is_potential_name "John Doe" >|= f)
+    is_positive (-10) >|= create >>= fun f -> is_potential_name "John Doe" >|= f
   in
   Alcotest.(check (option (pair int string)))
     "Sequential_Validation_2" expected computed
@@ -87,7 +83,7 @@ let sequential_validation_2 () =
 let sequential_validation_3 () =
   let expected = None
   and computed =
-    Monad.(is_positive 10 >|= create >>= (fun f -> is_potential_name "J" >|= f))
+    Monad.(is_positive 10 >|= create >>= fun f -> is_potential_name "J" >|= f)
   in
   Alcotest.(check (option (pair int string)))
     "Sequential_Validation_1" expected computed
@@ -97,7 +93,7 @@ let sequential_validation_4 () =
   let expected = None
   and computed =
     let open Monad in
-    is_positive (-10) >|= create >>= (fun f -> is_potential_name "J" >|= f)
+    is_positive (-10) >|= create >>= fun f -> is_potential_name "J" >|= f
   in
   Alcotest.(check (option (pair int string)))
     "Sequential_Validation_1" expected computed
@@ -124,7 +120,6 @@ let fold_map_over_values () =
     type t = int
 
     let neutral = 1
-
     let combine = ( * )
   end) in
   let expected = 120
@@ -137,7 +132,6 @@ let fold_map_over_empty () =
     type t = int
 
     let neutral = 1
-
     let combine = ( * )
   end) in
   let expected = 1

--- a/test/preface_stdlib_test/seq_test.ml
+++ b/test/preface_stdlib_test/seq_test.ml
@@ -9,7 +9,6 @@ let fold_map_over_values () =
     type t = int
 
     let neutral = 1
-
     let combine = ( * )
   end) in
   let expected = 120
@@ -27,7 +26,6 @@ let fold_map_over_empty () =
     type t = int
 
     let neutral = 1
-
     let combine = ( * )
   end) in
   let expected = 1

--- a/test/preface_stdlib_test/stream_test.ml
+++ b/test/preface_stdlib_test/stream_test.ml
@@ -7,7 +7,6 @@ let subject_try a =
 ;;
 
 let rec numbers n = stream n (lazy (numbers (n + 1)))
-
 let naturals = numbers 0
 
 let should_extract () =

--- a/test/preface_stdlib_test/traced_test.ml
+++ b/test/preface_stdlib_test/traced_test.ml
@@ -2,7 +2,6 @@ module I = Preface.Make.Monoid.Via_combine_and_neutral (struct
   type t = Int.t
 
   let neutral = 0
-
   let combine x y = x + y
 end)
 

--- a/test/preface_stdlib_test/try_test.ml
+++ b/test/preface_stdlib_test/try_test.ml
@@ -5,7 +5,6 @@ let subject a =
 ;;
 
 exception Invalid_name of string
-
 exception Invalid_age of int
 
 let validate_name (name, age) =


### PR DESCRIPTION
With this type alias, it is possible to describe a handler as follows:

```diff
 let run program =
-  let handler : type b . (b -> 'a') -> b IO.f -> 'a
+  let handler : type a. (a, 'b) IO.handle =
     fun resume -> function
       | Print message ->
         let () = print_endline message in
         resume ()
       | Read ->
          (* As before, here I should call the [read_line] but
             for the purposes of the demonstration I will assume
             that [read_line] returns "Xavier" all the time. *)
          resume "Xavier"
     in
   IO.run { handler } program
```