### PR TITLE
Add right-associative operators for contravariant part

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.20.1
+version = 0.21.0
 margin = 80
 max-indent = 68
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## dev (Unreleased)
 
+- Add right-associative operators for `Contravariant`, `Divisible` and `Decidable`  [**@xhtmlboi**](https://github.com/xhtmlboi)
 - Add `Bind` [**@d-plaindoux**](https://github.com/d-plaindoux)
 - Add `Apply` [**@d-plaindoux**](https://github.com/d-plaindoux)
 - Add `('a, 'b) handle` to simplify handlers for `Freer_monad` [**@xvw**](https://github.com/xvw)

--- a/lib/preface/preface.ml
+++ b/lib/preface/preface.ml
@@ -95,7 +95,9 @@ module Make = Preface_make
     the user the freedom to implement, or not, a function by wrapping the
     function definition in a value of this type:
 
-    {[ val f : [< `Derived | `Custom of 'a -> 'b ] ]}
+    {[
+      val f : [< `Derived | `Custom of 'a -> 'b ]
+    ]}
 
     Instead of relying on this kind of (rather clever!) trick, we decided to
     rely mainly on the module language.

--- a/lib/preface_make/contravariant.ml
+++ b/lib/preface_make/contravariant.ml
@@ -15,9 +15,13 @@ struct
   type 'a t = 'a Core.t
 
   let ( >$ ) x c = Operation.replace x c
+  let ( ^$ ) x c = Operation.replace x c
   let ( $< ) c x = Operation.replace x c
+  let ( &$ ) c x = Operation.replace x c
   let ( >$< ) f c = Core.contramap f c
+  let ( ^$^ ) f c = Core.contramap f c
   let ( >&< ) c f = Core.contramap f c
+  let ( ^&^ ) c f = Core.contramap f c
 end
 
 module Via

--- a/lib/preface_make/decidable.ml
+++ b/lib/preface_make/decidable.ml
@@ -31,6 +31,7 @@ struct
   include Divisible.Infix (Core) (Operation)
 
   let ( >|< ) = Operation.chosen
+  let ( ^|^ ) = Operation.chosen
 end
 
 module Via

--- a/lib/preface_make/divisible.ml
+++ b/lib/preface_make/divisible.ml
@@ -26,8 +26,11 @@ struct
   include Contravariant.Infix (Core) (Operation)
 
   let ( >*< ) = Operation.divided
+  let ( ^*^ ) = Operation.divided
   let ( >* ) x = Core.divide (fun x -> (x, ())) x
+  let ( ^* ) = ( >* )
   let ( *< ) x y = Core.divide (fun x -> ((), x)) x y
+  let ( &* ) = ( *< )
 end
 
 module Via

--- a/lib/preface_specs/contravariant.mli
+++ b/lib/preface_specs/contravariant.mli
@@ -43,14 +43,26 @@ module type INFIX = sig
   val ( >$ ) : 'b -> 'b t -> 'a t
   (** Infix version of {!val:OPERATION.replace}. *)
 
+  val ( ^$ ) : 'b -> 'b t -> 'a t
+  (** Right-associative version of [>$]. *)
+
   val ( $< ) : 'b t -> 'b -> 'a t
   (** Infix flipped version of {!val:OPERATION.replace}. *)
+
+  val ( &$ ) : 'b t -> 'b -> 'a t
+  (** Right-associative version of [$<]. *)
 
   val ( >$< ) : ('a -> 'b) -> 'b t -> 'a t
   (** Infix version of {!val:CORE.map}. *)
 
+  val ( ^$^ ) : ('a -> 'b) -> 'b t -> 'a t
+  (** Right-associative version of [>$<]. *)
+
   val ( >&< ) : 'b t -> ('a -> 'b) -> 'a t
   (** Infix flipped version of {!val:CORE.map}. *)
+
+  val ( ^&^ ) : 'b t -> ('a -> 'b) -> 'a t
+  (** Right-associative version of [>&<]. *)
 end
 
 (** {1 Complete API} *)

--- a/lib/preface_specs/decidable.mli
+++ b/lib/preface_specs/decidable.mli
@@ -70,6 +70,9 @@ module type INFIX = sig
   val ( >|< ) : 'a t -> 'b t -> ('a, 'b) Either.t t
   (** Infix version of [chosen]. *)
 
+  val ( ^|^ ) : 'a t -> 'b t -> ('a, 'b) Either.t t
+  (** Right-associative version of [>|<]. *)
+
   include Divisible.INFIX with type 'a t := 'a t
 end
 

--- a/lib/preface_specs/divisible.mli
+++ b/lib/preface_specs/divisible.mli
@@ -63,11 +63,20 @@ module type INFIX = sig
   val ( >*< ) : 'a t -> 'b t -> ('a * 'b) t
   (** Infix version of [divided]. *)
 
+  val ( ^*^ ) : 'a t -> 'b t -> ('a * 'b) t
+  (** Right-associative version of [>*<]. *)
+
   val ( >* ) : 'a t -> unit t -> 'a t
   (** Discard the value of the second argument. *)
 
+  val ( ^* ) : 'a t -> unit t -> 'a t
+  (** Right-associative version of [>*]. *)
+
   val ( *< ) : unit t -> 'a t -> 'a t
   (** Discard the value of the first argument. *)
+
+  val ( &* ) : unit t -> 'a t -> 'a t
+  (** Right-associative version of [*<]. *)
 
   include Contravariant.INFIX with type 'a t := 'a t
 end

--- a/test/preface_examples_test/template_reader.ml
+++ b/test/preface_examples_test/template_reader.ml
@@ -39,8 +39,7 @@ let should_transform_constant () =
 let should_transform_variable () =
   let expected = "Alice"
   and computed =
-    Reader.run_identity
-      (transform [ Var "name" ])
+    Reader.run_identity (transform [ Var "name" ])
       (Bindings.singleton "name" "Alice")
   in
   Alcotest.(check string) "transform_variable" expected computed


### PR DESCRIPTION
Fix #165
As mentioned in the ticket, the problem is not related to the implementation but to the precedence of the characters used in the operators. This branch adds `^x^` add-on versions to `>x<`. 