### PR TITLE
Update invariant.mli

### DIFF
--- a/lib/preface_specs/invariant.mli
+++ b/lib/preface_specs/invariant.mli
@@ -1,4 +1,4 @@
-(** [Invariant] is and "Invariant Functor". Every {!module:Functor} and
+(** [Invariant] is an "Invariant Functor". Every {!module:Functor} and
     {!module:Contravariant} is an Invariant Functor. *)
 
 (** {2 Laws}


### PR DESCRIPTION
typo.

What's more, section `Invariant` is in your doc (https://ocaml-preface.github.io/preface/Preface_specs/index.html#functor-hierarchy), but it's not shown on the ocaml v3 doc for your package(https://v3.ocaml.org/p/preface/0.1.0/doc/Preface_specs/index.html#functor-hierarchy).