### PR TITLE
Add Jaylang to the projects list in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,10 +234,11 @@ naming follows this convention: `Over_name (Req)`, ie
 
 ## Projects using Preface
 
-| Project name | Description                                                                                                                  | Links                                                   |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| **YOCaml**   | YOCaml is a static blog generator that essentially takes advantage of Preface's `Freer`, `Result`, `Validation` and `Arrow`. | [Github repository](https://github.com/xhtmlboi/yocaml) |
-| **Muhokama** | A simple forum built on top of Dream, Caqti, Omd, Preface, Cmdliner and other useful OCaml libraries                         | [Github repository](https://github.com/xvw/muhokama)    |
+| Project name | Description                                                                                                                  | Links                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **YOCaml**   | YOCaml is a static blog generator that essentially takes advantage of Preface's `Freer`, `Result`, `Validation` and `Arrow`. | [Github repository](https://github.com/xhtmlboi/yocaml)    |
+| **Muhokama** | A simple forum built on top of Dream, Caqti, Omd, Preface, Cmdliner and other useful OCaml libraries                         | [Github repository](https://github.com/xvw/muhokama)       |
+| **Jaylang**  | A semantically typed language that uses Preface for abstractions including `Arrow`, `Writer`, `Nonempty_list`, and more.     | [Github repository](https://github.com/JHU-PL-Lab/jaylang) |
 
 You use Preface for one of your projects and you want to be in this
 list? Don't hesitate to open a PR or fill an issue, we'd love to hear


### PR DESCRIPTION
This PR adds Jaylang to the projects list in the README.

Preface is used throughout the Jaylang repository to implement a semantically typed language.