### PR TITLE
Nonempty list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@
 - Add `Kleisli` and `Cokleisli` [**@gr-im**](https://github.com/gr-im)
 - Add `Join`, `Joker` and `Clown` [**@gr-im**](https://github.com/gr-im)
 - Relax constraint for definition of `Profunctor` and `Choice` using the Kleisli Arrow [**@gr-im**](https://github.com/gr-im)
-- Make `List` and `Nonenmpty_list` `Traversable` implementations (for both `Applicative` and `Monad`) Tail-recursive [**@xvw**](https://github.com/xvw)
+- Make `List` and `Nonempty_list` `Traversable` implementations (for both `Applicative` and `Monad`) Tail-recursive [**@xvw**](https://github.com/xvw)
 - Add `Seq` module in Stdlib (with `Functor`, `Applicative` (with `Traversable`), `Alternative`, `Monad` (with `Traversable`), `Monad_plus`, `Monoid` and `Foldable`) [**@xvw**](https://github.com/xvw)
 - Add `mli` for stdlib's test and example's test (in order to track unused tests) [**@xvw**](https://github.com/xvw)
 - Use absolute URLs for image in documentation (in order to fit with the new version of OCaml.org) [**@xvw**](https://github.com/xvw)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## vX.X.X (Unreleased)
+
+- Adopt a single variant representation for `Nonempty_list` as done in `YOCaml` and a few [other projects](https://github.com/ocaml/ocaml/discussions/14261) [**@mbarbin**](https://github.com/mbarbin), review by [**@xvw**](https://github.com/xvw)
+
 ## v1.1.0 (February 2025)
 
 - Some fixture for `5.3.0` [**@xvw**](https://github.com/xvw)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## vX.X.X (Unreleased)
 
-- Adopt a single variant representation for `Nonempty_list` as done in `YOCaml` and a few [other projects](https://github.com/ocaml/ocaml/discussions/14261) [**@mbarbin**](https://github.com/mbarbin), review by [**@xvw**](https://github.com/xvw)
+- **Breaking change** change representation for `Nonempty_list` as done in `YOCaml` and a few [other projects](https://github.com/ocaml/ocaml/discussions/14261) [**@mbarbin**](https://github.com/mbarbin), review by [**@xvw**](https://github.com/xvw)
 
 ## v1.1.0 (February 2025)
 

--- a/lib/preface_core/nonempty_list.ml
+++ b/lib/preface_core/nonempty_list.ml
@@ -3,55 +3,55 @@ type 'a t = ( :: ) of 'a * 'a list
 let create x = x :: []
 
 let rev_append (x :: xs) (y :: ys) =
-  match List.rev_append List.(x :: xs) List.(y :: ys) with
+  match List.rev_append xs (x :: y :: ys) with
   | [] -> assert false
-  | List.(z :: zs) -> z :: zs
+  | z :: zs -> z :: zs
 ;;
 
 let hd (x :: _) = x
-let tl = function _ :: [] -> None | _ :: y :: ys -> Some (y :: ys)
+let tl (_ :: xs) = match xs with [] -> None | y :: ys -> Some (y :: ys)
 
 let rev (x :: xs) =
-  match List.(rev (x :: xs)) with
-  | [] -> assert false
-  | List.(y :: ys) -> y :: ys
+  match List.rev (x :: xs) with [] -> assert false | y :: ys -> y :: ys
 ;;
 
-let from_list = function [] -> None | List.(x :: xs) -> Some (x :: xs)
+let from_list = function [] -> None | x :: xs -> Some (x :: xs)
 let to_list (x :: xs) = List.(x :: xs)
 let length (_ :: xs) = 1 + List.length xs
-let cons x (y :: ys) = x :: List.(y :: ys)
-let iteri f (x :: xs) = List.iteri f List.(x :: xs)
-let iter f (x :: xs) = List.iter f List.(x :: xs)
+let cons x (y :: ys) = x :: y :: ys
+let iteri f (x :: xs) = List.iteri f (x :: xs)
+
+let iter f (x :: xs) =
+  f x;
+  List.iter f xs
+;;
 
 let mapi f (x :: xs) =
-  match List.mapi f List.(x :: xs) with
-  | [] -> assert false
-  | List.(y :: ys) -> y :: ys
+  match List.mapi f (x :: xs) with [] -> assert false | y :: ys -> y :: ys
 ;;
 
 let map f (x :: xs) =
-  match List.map f List.(x :: xs) with
-  | [] -> assert false
-  | List.(y :: ys) -> y :: ys
+  let y = f x in
+  y :: List.map f xs
 ;;
 
-let fold_left f acc (x :: xs) = List.fold_left f acc List.(x :: xs)
+let fold_left f acc (x :: xs) = List.fold_left f (f acc x) xs
 let reduce f (x :: xs) = List.fold_left f x xs
-let fold_right f (x :: xs) acc = List.fold_right f List.(x :: xs) acc
-let append (x :: xs) (y :: ys) = x :: List.append xs List.(y :: ys)
-let flatten nel = reduce append nel
+let fold_right f (x :: xs) acc = List.fold_right f (x :: xs) acc
+let append (x :: xs) (y :: ys) = x :: List.append xs (y :: ys)
 
-let equal f (x :: xs) (y :: ys) =
-  f x y
-  &&
-  let rec aux = function
-    | [], [] -> true
-    | List.(a :: as'), List.(b :: bs') -> f a b && aux (as', bs')
-    | _ -> false
-  in
-  aux (xs, ys)
+let[@tail_mod_cons] rec flatten_list_of_nels = function
+  | [] -> []
+  | (x :: xs) :: ys -> x :: append_to_nels xs ys
+
+and[@tail_mod_cons] append_to_nels xs ys =
+  match xs with
+  | [] -> flatten_list_of_nels ys
+  | x :: xs -> x :: append_to_nels xs ys
 ;;
+
+let flatten ((x :: xs) :: ys) = x :: append_to_nels xs ys
+let equal f (x :: xs) (y :: ys) = f x y && List.equal f xs ys
 
 let pp pp' formater list =
   let pp_sep ppf () = Format.fprintf ppf ";@ " in

--- a/lib/preface_core/nonempty_list.ml
+++ b/lib/preface_core/nonempty_list.ml
@@ -1,4 +1,4 @@
-type 'a t = ( :: ) of ('a * 'a list)
+type 'a t = ( :: ) of 'a * 'a list
 
 let create x = x :: []
 

--- a/lib/preface_core/nonempty_list.ml
+++ b/lib/preface_core/nonempty_list.ml
@@ -1,133 +1,56 @@
-type 'a t =
-  | Last of 'a
-  | ( :: ) of ('a * 'a t)
+type 'a t = ( :: ) of ('a * 'a list)
 
-let create x = Last x
+let create x = x :: []
 
-let rec rev_append l1 l2 =
-  match l1 with Last x -> x :: l2 | x :: xs -> rev_append xs (x :: l2)
+let rev_append (x :: xs) (y :: ys) =
+  match List.rev_append List.(x :: xs) List.(y :: ys) with
+  | [] -> assert false
+  | List.(z :: zs) -> z :: zs
 ;;
 
-let hd = function Last x | x :: _ -> x
-let tl = function Last _ -> None | _ :: xs -> Some xs
+let hd (x :: _) = x
+let tl = function _ :: [] -> None | _ :: y :: ys -> Some (y :: ys)
 
-let rev = function
-  | Last x -> Last x
-  | x :: xs ->
-    let rec aux_rev acc = function
-      | Last x -> x :: acc
-      | x :: xs -> aux_rev (x :: acc) xs
-    in
-    aux_rev (Last x) xs
+let rev (x :: xs) =
+  match List.(rev (x :: xs)) with
+  | [] -> assert false
+  | List.(y :: ys) -> y :: ys
 ;;
 
-let from_list = function
-  | [] -> None
-  | List.( :: ) (x, xs) ->
-    let rec aux_from acc = function
-      | [] -> Some (rev acc)
-      | List.( :: ) (x, xs) -> aux_from (x :: acc) xs
-    in
-    aux_from (Last x) xs
+let from_list = function [] -> None | List.(x :: xs) -> Some (x :: xs)
+let to_list (x :: xs) = List.(x :: xs)
+let length (_ :: xs) = 1 + List.length xs
+let cons x (y :: ys) = x :: List.(y :: ys)
+let iteri f (x :: xs) = List.iteri f List.(x :: xs)
+let iter f (x :: xs) = List.iter f List.(x :: xs)
+
+let mapi f (x :: xs) =
+  match List.mapi f List.(x :: xs) with
+  | [] -> assert false
+  | List.(y :: ys) -> y :: ys
 ;;
 
-let to_list list =
-  let rec to_aux acc = function
-    | Last x -> List.(rev (x :: acc))
-    | x :: xs -> to_aux List.(x :: acc) xs
-  in
-  to_aux [] list
+let map f (x :: xs) =
+  match List.map f List.(x :: xs) with
+  | [] -> assert false
+  | List.(y :: ys) -> y :: ys
 ;;
 
-let length list =
-  let rec length_aux acc = function
-    | Last _ -> acc + 1
-    | _ :: xs -> length_aux (acc + 1) xs
-  in
-  length_aux 0 list
-;;
+let fold_left f acc (x :: xs) = List.fold_left f acc List.(x :: xs)
+let reduce f (x :: xs) = List.fold_left f x xs
+let fold_right f (x :: xs) acc = List.fold_right f List.(x :: xs) acc
+let append (x :: xs) (y :: ys) = x :: List.append xs List.(y :: ys)
+let flatten nel = reduce append nel
 
-let cons x xs = x :: xs
-
-let iteri f list =
-  let rec iter_aux acc = function
-    | Last x -> f acc x
-    | x :: xs ->
-      let () = f acc x in
-      iter_aux (acc + 1) xs
-  in
-  iter_aux 0 list
-;;
-
-let iter f list =
-  let f' _ x = f x in
-  iteri f' list
-;;
-
-let mapi f = function
-  | Last x -> Last (f 0 x)
-  | x :: xs ->
-    let rec map_aux i acc = function
-      | Last x -> rev (f i x :: acc)
-      | x :: xs -> map_aux (i + 1) (f i x :: acc) xs
-    in
-    map_aux 1 (Last (f 0 x)) xs
-;;
-
-let map f list =
-  let f' _ x = f x in
-  mapi f' list
-;;
-
-let fold_left f acc = function
-  | Last x -> f acc x
-  | x :: xs ->
-    let rec fold_aux acc = function
-      | Last x -> f acc x
-      | x :: xs -> fold_aux (f acc x) xs
-    in
-    fold_aux (f acc x) xs
-;;
-
-let reduce f = function Last x -> x | x :: xs -> fold_left f x xs
-
-let fold_right f list acc =
-  match list with
-  | Last x -> f x acc
-  | x :: xs ->
-    let rec fold_aux acc = function
-      | Last x -> f x acc
-      | x :: xs -> f x (fold_aux acc xs)
-    in
-    f x (fold_aux acc xs)
-;;
-
-let append a' b =
-  let a = rev a' in
-  let rec append_aux acc = function
-    | Last x -> x :: acc
-    | x :: xs -> append_aux (x :: acc) xs
-  in
-  append_aux b a
-;;
-
-let flatten = function
-  | Last x -> x
-  | xs ->
-    let rec flatten_aux = function
-      | Last x -> x
-      | x :: xs -> append x (flatten_aux xs)
-    in
-    flatten_aux xs
-;;
-
-let equal f a b =
-  let rec eq_aux = function
-    | Last x, Last y -> f x y
-    | x :: xs, y :: ys -> f x y && eq_aux (xs, ys)
+let equal f (x :: xs) (y :: ys) =
+  f x y
+  &&
+  let rec aux = function
+    | [], [] -> true
+    | List.(a :: as'), List.(b :: bs') -> f a b && aux (as', bs')
     | _ -> false
   in
-  eq_aux (a, b)
+  aux (xs, ys)
 ;;
 
 let pp pp' formater list =

--- a/lib/preface_core/nonempty_list.ml
+++ b/lib/preface_core/nonempty_list.ml
@@ -1,22 +1,21 @@
 type 'a t = ( :: ) of 'a * 'a list
 
 let create x = x :: []
+let to_list (x :: xs) = List.(x :: xs)
 
-let rev_append (x :: xs) (y :: ys) =
-  match List.rev_append xs (x :: y :: ys) with
-  | [] -> assert false
-  | z :: zs -> z :: zs
+let rev_append_to_list (x :: xs) l2 =
+  let rec aux acc first = function
+    | List.[] -> first :: acc
+    | List.(x :: xs) -> aux (first :: acc) x xs
+  in
+  aux l2 x xs
 ;;
 
+let rev_append t1 t2 = rev_append_to_list t1 (to_list t2)
 let hd (x :: _) = x
 let tl (_ :: xs) = match xs with [] -> None | y :: ys -> Some (y :: ys)
-
-let rev (x :: xs) =
-  match List.rev (x :: xs) with [] -> assert false | y :: ys -> y :: ys
-;;
-
+let rev t = rev_append_to_list t []
 let from_list = function [] -> None | x :: xs -> Some (x :: xs)
-let to_list (x :: xs) = List.(x :: xs)
 let length (_ :: xs) = 1 + List.length xs
 let cons x (y :: ys) = x :: y :: ys
 let iteri f (x :: xs) = List.iteri f (x :: xs)

--- a/lib/preface_core/nonempty_list.mli
+++ b/lib/preface_core/nonempty_list.mli
@@ -1,7 +1,7 @@
 (** A Non empty list. The module allows to deal with non-empty list. Lists where
     the minimum size is one.*)
 
-type 'a t = ( :: ) of ('a * 'a list)
+type 'a t = ( :: ) of 'a * 'a list
 
 val create : 'a -> 'a t
 (** [create x] create a new non-empty list with [x]. *)

--- a/lib/preface_core/nonempty_list.mli
+++ b/lib/preface_core/nonempty_list.mli
@@ -1,9 +1,7 @@
 (** A Non empty list. The module allows to deal with non-empty list. Lists where
     the minimum size is one.*)
 
-type 'a t =
-  | Last of 'a
-  | ( :: ) of ('a * 'a t)
+type 'a t = ( :: ) of ('a * 'a list)
 
 val create : 'a -> 'a t
 (** [create x] create a new non-empty list with [x]. *)

--- a/lib/preface_specs/comonad.mli
+++ b/lib/preface_specs/comonad.mli
@@ -3,7 +3,7 @@
 (** {2 Laws}
 
     - [extend extract = id]
-    - [(extend %> extract) f = f]
+    - [extend f %> extract = f]
     - [extend g %> extend f = extend (extend g %> f)]
     - [f =>= extract = f]
     - [extract =>= f = f]

--- a/lib/preface_stdlib/nonempty_list.ml
+++ b/lib/preface_stdlib/nonempty_list.ml
@@ -1,6 +1,4 @@
-type 'a t = 'a Preface_core.Nonempty_list.t =
-  | Last of 'a
-  | ( :: ) of ('a * 'a t)
+type 'a t = 'a Preface_core.Nonempty_list.t = ( :: ) of ('a * 'a list)
 
 include (
   Preface_core.Nonempty_list :
@@ -44,15 +42,13 @@ module Applicative_traversable (A : Preface_specs.APPLICATIVE) =
       type 'a t = 'a A.t
       type 'a iter = 'a Preface_core.Nonempty_list.t
 
-      let traverse f l =
+      let traverse f (x :: xs) =
         let open A.Infix in
         let rec traverse_aux acc = function
-          | Last x -> rev <$> A.lift2 cons (f x) acc
-          | x :: xs -> traverse_aux (A.lift2 cons (f x) acc) xs
+          | [] -> rev <$> acc
+          | y :: ys -> traverse_aux (A.lift2 cons (f y) acc) ys
         in
-        match l with
-        | Last x -> create <$> f x
-        | x :: xs -> traverse_aux (create <$> f x) xs
+        traverse_aux (create <$> f x) xs
       ;;
     end)
 
@@ -76,15 +72,13 @@ module Monad_traversable (M : Preface_specs.MONAD) =
       type 'a t = 'a M.t
       type 'a iter = 'a Preface_core.Nonempty_list.t
 
-      let traverse f l =
+      let traverse f (x :: xs) =
         let open M.Infix in
         let rec traverse_aux acc = function
-          | Last x -> rev <$> M.lift2 cons (f x) acc
-          | x :: xs -> traverse_aux (M.lift2 cons (f x) acc) xs
+          | [] -> rev <$> acc
+          | y :: ys -> traverse_aux (M.lift2 cons (f y) acc) ys
         in
-        match l with
-        | Last x -> f x >|= create
-        | x :: xs -> traverse_aux (f x >|= create) xs
+        traverse_aux (f x >|= create) xs
       ;;
     end)
 
@@ -101,10 +95,15 @@ module Invariant = Preface_make.Invariant.From_functor (Functor)
 module Comonad = Preface_make.Comonad.Via_extend (struct
   type nonrec 'a t = 'a t
 
-  let extract = function Last x | x :: _ -> x
+  let extract (x :: _) = x
 
-  let rec extend f nel =
-    match nel with Last _ -> Last (f nel) | _ :: xs -> f nel :: extend f xs
+  let extend f nel =
+    let rec aux acc nel =
+      match nel with
+      | _ :: [] -> rev (f nel :: acc)
+      | _ :: y :: ys -> aux (f nel :: acc) (y :: ys)
+    in
+    aux [] nel
   ;;
 end)
 

--- a/lib/preface_stdlib/nonempty_list.ml
+++ b/lib/preface_stdlib/nonempty_list.ml
@@ -97,13 +97,11 @@ module Comonad = Preface_make.Comonad.Via_extend (struct
 
   let extract (x :: _) = x
 
-  let extend f nel =
-    let rec aux acc nel =
-      match nel with
-      | _ :: [] -> rev (f nel :: acc)
-      | _ :: y :: ys -> aux (f nel :: acc) (y :: ys)
+  let extend f (_ :: xs as nel) =
+    let[@tail_mod_cons] rec aux f xs =
+      match xs with [] -> [] | hd :: tl -> f (hd :: tl) :: aux f tl
     in
-    aux [] nel
+    f nel :: aux f xs
   ;;
 end)
 

--- a/lib/preface_stdlib/nonempty_list.ml
+++ b/lib/preface_stdlib/nonempty_list.ml
@@ -49,7 +49,8 @@ module Applicative_traversable (A : Preface_specs.APPLICATIVE) =
           | [] -> Stdlib.List.rev <$> acc
           | y :: ys -> traverse_tail (A.lift2 Stdlib.List.cons (f y) acc) ys
         in
-        A.lift2 cons' (f x) (traverse_tail (A.pure []) xs)
+        let fx = f x in
+        A.lift2 cons' fx (traverse_tail (A.pure []) xs)
       ;;
     end)
 
@@ -79,7 +80,8 @@ module Monad_traversable (M : Preface_specs.MONAD) =
           | [] -> Stdlib.List.rev <$> acc
           | y :: ys -> traverse_tail (M.lift2 Stdlib.List.cons (f y) acc) ys
         in
-        M.lift2 cons' (f x) (traverse_tail (M.return []) xs)
+        let fx = f x in
+        M.lift2 cons' fx (traverse_tail (M.return []) xs)
       ;;
     end)
 
@@ -100,9 +102,14 @@ module Comonad = Preface_make.Comonad.Via_extend (struct
 
   let extend f (_ :: xs as nel) =
     let[@tail_mod_cons] rec aux f xs =
-      match xs with [] -> [] | hd :: tl -> f (hd :: tl) :: aux f tl
+      match xs with
+      | [] -> []
+      | hd :: tl ->
+        let fhd = f (hd :: tl) in
+        fhd :: aux f tl
     in
-    f nel :: aux f xs
+    let fnel = f nel in
+    fnel :: aux f xs
   ;;
 end)
 

--- a/lib/preface_stdlib/nonempty_list.ml
+++ b/lib/preface_stdlib/nonempty_list.ml
@@ -1,4 +1,4 @@
-type 'a t = 'a Preface_core.Nonempty_list.t = ( :: ) of ('a * 'a list)
+type 'a t = 'a Preface_core.Nonempty_list.t = ( :: ) of 'a * 'a list
 
 include (
   Preface_core.Nonempty_list :

--- a/lib/preface_stdlib/nonempty_list.ml
+++ b/lib/preface_stdlib/nonempty_list.ml
@@ -5,6 +5,7 @@ include (
     module type of Preface_core.Nonempty_list with type 'a t := 'a t )
 
 let pure x = create x
+let cons' hd tl = hd :: tl
 
 module Foldable = Preface_make.Foldable.Via_fold_right (struct
   type nonrec 'a t = 'a t
@@ -44,11 +45,11 @@ module Applicative_traversable (A : Preface_specs.APPLICATIVE) =
 
       let traverse f (x :: xs) =
         let open A.Infix in
-        let rec traverse_aux acc = function
-          | [] -> rev <$> acc
-          | y :: ys -> traverse_aux (A.lift2 cons (f y) acc) ys
+        let rec traverse_tail acc = function
+          | [] -> Stdlib.List.rev <$> acc
+          | y :: ys -> traverse_tail (A.lift2 Stdlib.List.cons (f y) acc) ys
         in
-        traverse_aux (create <$> f x) xs
+        A.lift2 cons' (f x) (traverse_tail (A.pure []) xs)
       ;;
     end)
 
@@ -74,11 +75,11 @@ module Monad_traversable (M : Preface_specs.MONAD) =
 
       let traverse f (x :: xs) =
         let open M.Infix in
-        let rec traverse_aux acc = function
-          | [] -> rev <$> acc
-          | y :: ys -> traverse_aux (M.lift2 cons (f y) acc) ys
+        let rec traverse_tail acc = function
+          | [] -> Stdlib.List.rev <$> acc
+          | y :: ys -> traverse_tail (M.lift2 Stdlib.List.cons (f y) acc) ys
         in
-        traverse_aux (f x >|= create) xs
+        M.lift2 cons' (f x) (traverse_tail (M.return []) xs)
       ;;
     end)
 

--- a/lib/preface_stdlib/nonempty_list.mli
+++ b/lib/preface_stdlib/nonempty_list.mli
@@ -5,7 +5,7 @@
 
 (** {1 Type} *)
 
-type 'a t = 'a Preface_core.Nonempty_list.t = ( :: ) of ('a * 'a list)
+type 'a t = 'a Preface_core.Nonempty_list.t = ( :: ) of 'a * 'a list
 
 (** {1 Implementation} *)
 

--- a/lib/preface_stdlib/nonempty_list.mli
+++ b/lib/preface_stdlib/nonempty_list.mli
@@ -5,9 +5,7 @@
 
 (** {1 Type} *)
 
-type 'a t = 'a Preface_core.Nonempty_list.t =
-  | Last of 'a
-  | ( :: ) of ('a * 'a t)
+type 'a t = 'a Preface_core.Nonempty_list.t = ( :: ) of ('a * 'a list)
 
 (** {1 Implementation} *)
 

--- a/test/preface_core_test/nonempty_list_test.ml
+++ b/test/preface_core_test/nonempty_list_test.ml
@@ -7,20 +7,20 @@ let nel_testable a =
 open Preface_core.Nonempty_list
 
 let should_create () =
-  let expected = Last 10
+  let expected = [ 10 ]
   and computed = create 10 in
   Alcotest.(check (nel_testable int)) "should_create" expected computed
 ;;
 
 let should_create_from_list_nonempty () =
-  let expected = Some (10 :: 11 :: 12 :: Last 13)
+  let expected = Some [ 10; 11; 12; 13 ]
   and computed = from_list [ 10; 11; 12; 13 ] in
   Alcotest.(check (option (nel_testable int)))
     "should_create_from_list_nonempty" expected computed
 ;;
 
 let should_create_from_list_singleton () =
-  let expected = Some (Last 10)
+  let expected = Some [ 10 ]
   and computed = from_list [ 10 ] in
   Alcotest.(check (option (nel_testable int)))
     "should_create_from_list_singleton" expected computed
@@ -59,7 +59,7 @@ let should_extract_empty_list () =
 ;;
 
 let should_extract_list () =
-  let expected = Some (300 :: 400 :: Last 500)
+  let expected = Some [ 300; 400; 500 ]
   and computed = tl (cons 200 (cons 300 (cons 400 (create 500)))) in
   Alcotest.(check (option (nel_testable int)))
     "should_extract_list" expected computed
@@ -78,7 +78,7 @@ let should_have_length_4 () =
 ;;
 
 let should_cons () =
-  let expected = 200 :: 300 :: 400 :: Last 500
+  let expected = [ 200; 300; 400; 500 ]
   and computed = cons 200 (cons 300 (cons 400 (create 500))) in
   Alcotest.(check (nel_testable int)) "should_cons" expected computed
 ;;
@@ -90,7 +90,7 @@ let should_rev_singleton () =
 ;;
 
 let should_rev () =
-  let expected = 500 :: 400 :: 300 :: Last 200
+  let expected = [ 500; 400; 300; 200 ]
   and computed = rev (cons 200 (cons 300 (cons 400 (create 500)))) in
   Alcotest.(check (nel_testable int)) "should_rev_singleton" expected computed
 ;;
@@ -99,7 +99,7 @@ let should_iteri_1 () =
   let expected = List.[ (0, 1); (1, 2); (2, 3) ]
   and computed =
     let x = ref [] in
-    let () = iteri (fun i e -> x := !x @ [ (i, e) ]) (1 :: 2 :: Last 3) in
+    let () = iteri (fun i e -> x := !x @ [ (i, e) ]) [ 1; 2; 3 ] in
     !x
   in
   Alcotest.(check (list (pair int int))) "should_iteri_1" expected computed
@@ -109,7 +109,7 @@ let should_iteri_2 () =
   let expected = List.[ (0, 10) ]
   and computed =
     let x = ref [] in
-    let () = iteri (fun i e -> x := !x @ [ (i, e) ]) (Last 10) in
+    let () = iteri (fun i e -> x := !x @ [ (i, e) ]) [ 10 ] in
     !x
   in
   Alcotest.(check (list (pair int int))) "should_iteri_1" expected computed
@@ -119,7 +119,7 @@ let should_iter_1 () =
   let expected = List.[ (0, 1); (1, 2); (2, 3) ]
   and computed =
     let x = ref [] in
-    let () = iter (fun e -> x := !x @ [ (e - 1, e) ]) (1 :: 2 :: Last 3) in
+    let () = iter (fun e -> x := !x @ [ (e - 1, e) ]) [ 1; 2; 3 ] in
     !x
   in
   Alcotest.(check (list (pair int int))) "should_iteri_1" expected computed
@@ -129,81 +129,77 @@ let should_iter_2 () =
   let expected = List.[ (9, 10) ]
   and computed =
     let x = ref [] in
-    let () = iter (fun e -> x := !x @ [ (e - 1, e) ]) (Last 10) in
+    let () = iter (fun e -> x := !x @ [ (e - 1, e) ]) [ 10 ] in
     !x
   in
   Alcotest.(check (list (pair int int))) "should_iteri_1" expected computed
 ;;
 
 let should_mapi_1 () =
-  let expected = (0, "1") :: (1, "2") :: (2, "3") :: Last (3, "4")
-  and computed =
-    mapi (fun i x -> (i, string_of_int x)) (1 :: 2 :: 3 :: Last 4)
-  in
+  let expected = [ (0, "1"); (1, "2"); (2, "3"); (3, "4") ]
+  and computed = mapi (fun i x -> (i, string_of_int x)) [ 1; 2; 3; 4 ] in
   Alcotest.(check (nel_testable (pair int string)))
     "should_mapi_1" expected computed
 ;;
 
 let should_mapi_2 () =
-  let expected = Last (0, "1")
-  and computed = mapi (fun i x -> (i, string_of_int x)) (Last 1) in
+  let expected = [ (0, "1") ]
+  and computed = mapi (fun i x -> (i, string_of_int x)) [ 1 ] in
   Alcotest.(check (nel_testable (pair int string)))
     "should_mapi_1" expected computed
 ;;
 
 let should_map_1 () =
-  let expected = "11" :: "12" :: "13" :: Last "14"
-  and computed =
-    map (fun x -> string_of_int (x + 10)) (1 :: 2 :: 3 :: Last 4)
-  in
+  let expected = [ "11"; "12"; "13"; "14" ]
+  and computed = map (fun x -> string_of_int (x + 10)) [ 1; 2; 3; 4 ] in
   Alcotest.(check (nel_testable string)) "should_mapi_1" expected computed
 ;;
 
 let should_map_2 () =
-  let expected = Last "11"
-  and computed = map (fun x -> string_of_int (x + 10)) (Last 1) in
+  let expected = [ "11" ]
+  and computed = map (fun x -> string_of_int (x + 10)) [ 1 ] in
   Alcotest.(check (nel_testable string)) "should_mapi_1" expected computed
 ;;
 
 let should_fold_left_1 () =
   let expected = "HelloPrefaceOCaml"
   and computed =
-    fold_left (fun a x -> a ^ x) "" ("Hello" :: "Preface" :: Last "OCaml")
+    fold_left (fun a x -> a ^ x) "" [ "Hello"; "Preface"; "OCaml" ]
   in
   Alcotest.(check string) "should_fold_left_1" expected computed
 ;;
 
 let should_fold_left_2 () =
   let expected = "Hello"
-  and computed = fold_left (fun a x -> a ^ x) "" (Last "Hello") in
+  and computed = fold_left (fun a x -> a ^ x) "" [ "Hello" ] in
   Alcotest.(check string) "should_fold_left_2" expected computed
 ;;
 
 let should_fold_right_1 () =
   let expected = "FooOCamlPrefaceHello"
   and computed =
-    fold_right (fun x a -> a ^ x) ("Hello" :: "Preface" :: Last "OCaml") "Foo"
+    fold_right (fun x a -> a ^ x) [ "Hello"; "Preface"; "OCaml" ] "Foo"
   in
   Alcotest.(check string) "should_fold_right_1" expected computed
 ;;
 
 let should_fold_right_2 () =
   let expected = "BarHello"
-  and computed = fold_right (fun x a -> a ^ x) (Last "Hello") "Bar" in
+  and computed = fold_right (fun x a -> a ^ x) [ "Hello" ] "Bar" in
   Alcotest.(check string) "should_fold_right_2" expected computed
 ;;
 
 let should_append () =
-  let expected = 1 :: 2 :: 3 :: 4 :: 5 :: Last 6
-  and computed = append (1 :: 2 :: Last 3) (4 :: 5 :: Last 6) in
+  let expected = [ 1; 2; 3; 4; 5; 6 ]
+  and computed = append [ 1; 2; 3 ] [ 4; 5; 6 ] in
   Alcotest.(check (nel_testable int)) "should_append" expected computed
 ;;
 
 let should_rev_append () =
   let expected = List.[ 1; 2; 3; 4; 5; 6 ]
   and computed =
-    let l1 = 3 :: 2 :: Last 1
-    and l2 = 4 :: 5 :: Last 6 in
+    let l1 = [ 3; 2; 1 ]
+    and l2 = [ 4; 5; 6 ] in
     to_list (rev_append l1 l2)
   in
   Alcotest.(check (list int))
@@ -211,16 +207,14 @@ let should_rev_append () =
 ;;
 
 let should_flatten_1 () =
-  let expected = 1 :: 2 :: 3 :: 4 :: 5 :: Last 6
-  and computed =
-    flatten ((1 :: Last 2) :: (3 :: Last 4) :: Last (5 :: Last 6))
-  in
+  let expected = [ 1; 2; 3; 4; 5; 6 ]
+  and computed = flatten [ [ 1; 2 ]; [ 3; 4 ]; [ 5; 6 ] ] in
   Alcotest.(check (nel_testable int)) "should_flatten_1" expected computed
 ;;
 
 let should_flatten_2 () =
-  let expected = Last 1
-  and computed = flatten (Last (Last 1)) in
+  let expected = [ 1 ]
+  and computed = flatten [ [ 1 ] ] in
   Alcotest.(check (nel_testable int)) "should_flatten_2" expected computed
 ;;
 

--- a/test/preface_examples_test/formlet.ml
+++ b/test/preface_examples_test/formlet.ml
@@ -96,9 +96,7 @@ let validation_formlet_invalid2 () =
   let expected =
     invalid
       (let open Formlet in
-       let open Nel in
-       Invalid_name ("firstname", "") :: create (Invalid_name ("lastname", "-"))
-      )
+       [ Invalid_name ("firstname", ""); Invalid_name ("lastname", "-") ] )
   and computed =
     let open Applicative.Infix in
     let open Formlet in
@@ -133,11 +131,12 @@ let validation_formlet_invalid4 () =
   let expected =
     invalid
       (let open Formlet in
-       let open Nel in
-       Invalid_age (-5)
-       :: Invalid_name ("firstname", "")
-       :: Invalid_name ("lastname", "-")
-       :: create Unchecked_rules )
+       [
+         Invalid_age (-5)
+       ; Invalid_name ("firstname", "")
+       ; Invalid_name ("lastname", "-")
+       ; Unchecked_rules
+       ] )
   and computed =
     let open Applicative.Infix in
     let open Formlet in

--- a/test/preface_examples_test/free_applicative_formlet.ml
+++ b/test/preface_examples_test/free_applicative_formlet.ml
@@ -145,9 +145,7 @@ let test_with_invalid_user_missing_name () =
 
 let test_with_invalid_user_missing_name_and_invalid_age () =
   let expected =
-    Preface.(
-      Validate.invalid
-        Nonempty_list.(Invalid_int "coq" :: Last (Missing_field "name")) )
+    Preface.Validate.invalid [ Invalid_int "coq"; Missing_field "name" ]
   and computed = run [ ("age", "coq"); ("nickname", "XHTMLBoy") ] in
   Alcotest.(check validated_user_testable)
     "user should be invalid" expected computed

--- a/test/preface_examples_test/shape.ml
+++ b/test/preface_examples_test/shape.ml
@@ -78,7 +78,7 @@ let validation_shape_3 () =
 
 let validation_shape_4 () =
   let open Preface.Validate in
-  let expected = invalid Nel.(Shape.Fail "width" :: create (Shape.Fail "height"))
+  let expected = invalid [ Shape.Fail "width"; Shape.Fail "height" ]
   and computed =
     Shape.make (valid false)
       (invalid (Nel.create (Shape.Fail "radius")))

--- a/test/preface_laws_test/req.ml
+++ b/test/preface_laws_test/req.ml
@@ -134,7 +134,7 @@ module Nonempty_list = struct
     let* xs = list_size (int_bound 4) x in
     let+ x = x in
     Stdlib.List.fold_left
-      Preface.Nonempty_list.(fun acc x -> x :: acc)
+      Preface.Nonempty_list.(fun acc x -> cons x acc)
       (Preface.Nonempty_list.create x)
       xs
   ;;

--- a/test/preface_stdlib_test/nonempty_list_test.ml
+++ b/test/preface_stdlib_test/nonempty_list_test.ml
@@ -6,8 +6,8 @@ let nel_testable a =
 
 let should_traverse_without_failure_app () =
   let open Nel.Applicative.Traversable (Preface.Option.Applicative) in
-  let expected = Some Nel.(1 :: 2 :: create 3)
-  and computed = sequence Nel.(Some 1 :: Some 2 :: create (Some 3)) in
+  let expected : _ Nel.t option = Some [ 1; 2; 3 ]
+  and computed = sequence [ Some 1; Some 2; Some 3 ] in
   Alcotest.(check (option (nel_testable int)))
     "should_traverse_without_failure" expected computed
 ;;
@@ -15,15 +15,15 @@ let should_traverse_without_failure_app () =
 let should_traverse_with_failure_app () =
   let open Nel.Applicative.Traversable (Preface.Option.Applicative) in
   let expected = None
-  and computed = sequence Nel.(Some 1 :: None :: create (Some 3)) in
+  and computed = sequence [ Some 1; None; Some 3 ] in
   Alcotest.(check (option (nel_testable int)))
     "should_traverse_with_failure" expected computed
 ;;
 
 let should_traverse_without_failure_monad () =
   let open Nel.Monad.Traversable (Preface.Option.Monad) in
-  let expected = Some Nel.(1 :: 2 :: create 3)
-  and computed = sequence Nel.(Some 1 :: Some 2 :: create (Some 3)) in
+  let expected : _ Nel.t option = Some [ 1; 2; 3 ]
+  and computed = sequence [ Some 1; Some 2; Some 3 ] in
   Alcotest.(check (option (nel_testable int)))
     "should_traverse_without_failure" expected computed
 ;;
@@ -31,7 +31,7 @@ let should_traverse_without_failure_monad () =
 let should_traverse_with_failure_monad () =
   let open Nel.Monad.Traversable (Preface.Option.Monad) in
   let expected = None
-  and computed = sequence Nel.(Some 1 :: None :: create (Some 3)) in
+  and computed = sequence [ Some 1; None; Some 3 ] in
   Alcotest.(check (option (nel_testable int)))
     "should_traverse_with_failure" expected computed
 ;;


### PR DESCRIPTION
I got curious at one point about different implementations of the nonempty list in the OCaml ecosystem and started compiling a (nonempty-)list [here](https://github.com/ocaml/ocaml/discussions/14261).

I discovered this one from `Preface` sometimes recently and wanted to explore what another representation used in other project would look like for Preface.

This is mostly exploratory work, executed with the help of Claude Code Opus 4.5. In the commit history I explain which commits are from Claude and which are from me.

Status: I started from a vibe-coded PR and gradually working through reviewing it (not completed at this time).